### PR TITLE
Fix NumPy 2.0 deprecation: replace np.trapz with np.trapezoid

### DIFF
--- a/src/mors/spectrum.py
+++ b/src/mors/spectrum.py
@@ -106,13 +106,13 @@ class Spectrum():
             # With idxs defined, integrate over band
             band_wl = self.wl[idxs]
             band_fl = self.fl[idxs]
-            self.fl_integ[b] = np.trapz(band_fl,band_wl)
+            self.fl_integ[b] = np.trapezoid(band_fl,band_wl)
 
             # Reset idxs
             idxs = []
 
         # For bolometric "band"
-        self.fl_integ["bo"] = np.trapz(self.fl,self.wl)
+        self.fl_integ["bo"] = np.trapezoid(self.fl,self.wl)
 
         return self.fl_integ
 

--- a/src/mors/synthesis.py
+++ b/src/mors/synthesis.py
@@ -70,7 +70,7 @@ def GetProperties(Mstar:float, pctle:float, age:float):
     wl_pl = np.logspace(np.log10(spec.bands_limits["pl"][0]), np.log10(spec.bands_limits["pl"][1]), 1000)
     fl_pl = spec.PlanckFunction_surf(wl_pl, Tstar)
     fl_pl = spec.ScaleTo1AU(fl_pl, Rstar)
-    out["F_pl"] = np.trapz(fl_pl, wl_pl)
+    out["F_pl"] = np.trapezoid(fl_pl, wl_pl)
     out["L_pl"] = out["F_pl"] * area
 
     # Get flux of UV band from remainder


### PR DESCRIPTION
This pull request updates the numerical integration method used in the `CalcBandFluxes` function of `src/mors/spectrum.py`. The change replaces the deprecated `np.trapz` function with the newer `np.trapezoid` function from NumPy to ensure compatibility with recent versions of the library. Related to https://github.com/FormingWorlds/PROTEUS/issues/568. @stuitje @nichollsh This addresses one issue discussed on Discord and in https://github.com/FormingWorlds/PROTEUS/pull/575, but not the other issue that @stuitje is working on inside MORS. Apologies for me stumbling into this, but I had to fix this quickly to be able to move on with some other PROTEUS-level implementation.

Numerical integration method update:

* Replaced `np.trapz` with `np.trapezoid` for integrating flux over wavelength bands and for the bolometric band in the `CalcBandFluxes` method.