### PR TITLE
Fix the habitable-zone cubic term and four related source bugs

### DIFF
--- a/src/mors/baraffe.py
+++ b/src/mors/baraffe.py
@@ -1,17 +1,19 @@
 """Module for loading and interpolating Baraffe tracks data.
 Original tracks data can be found on the website
 http://perso.ens-lyon.fr/isabelle.baraffe/BHAC15dir/BHAC15_tracks+structure"""
-import os
-import shutil
+from __future__ import annotations
 
 import logging
-log = logging.getLogger("fwl."+__name__)
+import os
+import shutil
 
 import numpy as np
 from scipy.interpolate import PchipInterpolator
 
 import mors.constants as const
 from mors.data import FWL_DATA_DIR
+
+log = logging.getLogger("fwl." + __name__)
 
 #Short cut to Baraffe tracks mass and temporal range
 MassGrid = [0.010, 0.015, 0.020, 0.030, 0.040, 0.050,
@@ -250,9 +252,9 @@ def BaraffeLoadTrack(Mstar, pre_interp = True, tmin = None, tmax = None):
     path = (FWL_DATA_DIR / 'stellar_evolution_tracks' / 'Baraffe' / filename)
     if not path.exists():
         raise IOError(
-            "Cannot find Baraffe track file {path}. "
+            f"Cannot find Baraffe track file {path}. "
             "Did you set the FWL_DATA environment variable? "
-            "Did you run `mors dowload ...` to get access to the Baraffe track data?"
+            "Did you run `mors download baraffe` to get the Baraffe track data?"
         )
 
     data = np.loadtxt(path, skiprows=1).T
@@ -267,8 +269,10 @@ def BaraffeLoadTrack(Mstar, pre_interp = True, tmin = None, tmax = None):
     if pre_interp:
         # Params for interpolation
         grid_count = 5e4
-        if tmin==None: tmin = t[0]
-        if tmax==None: tmax = t[-1]
+        if tmin is None:
+            tmin = t[0]
+        if tmax is None:
+            tmax = t[-1]
 
         # Do interpolation
         #log.info("Interpolating stellar track onto a grid of size %d" % grid_count)

--- a/src/mors/cluster.py
+++ b/src/mors/cluster.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 # Imports for standard stuff needed here
+import copy
 import logging
 import pickle
 
@@ -54,8 +55,10 @@ class Cluster:
         # Set number of stars
         self.nStars = len(Mstar)
 
-        # Set parameters
-        self.params = params
+        # Set parameters. Copy the passed dictionary so enabling ExtendedTracks
+        # below stays local to this cluster and does not mutate the shared
+        # default dictionary that other stars and clusters read from.
+        self.params = copy.deepcopy(params)
 
         # Set the ExtendedTracks parameter to True so we get all parameters
         self.params['ExtendedTracks'] = True

--- a/src/mors/physicalmodel.py
+++ b/src/mors/physicalmodel.py
@@ -1,15 +1,19 @@
 """Module for holding functions for calculating physical quantities for the physical rotation and activity model."""
 
 # Imports for standard stuff needed here
-import numpy as np
-import sys as sys
+from __future__ import annotations
+
 import copy as copy
+import sys as sys
+
+import numpy as np
+
+import mors.constants as const
 
 # Imports for mors modules
-import mors.miscellaneous as misc
-import mors.stellarevo as SE
-import mors.constants as const
 import mors.parameters as params
+import mors.stellarevo as SE
+
 
 def dOmegadt(Mstar=None,Age=None,OmegaEnv=None,OmegaCore=None,params=params.paramsDefault,StarEvo=None):
     """Takes basic stellar parameters, returns rates of change of rotation.
@@ -113,7 +117,6 @@ def RotationQuantities(Mstar=None,Age=None,OmegaEnv=None,OmegaCore=None,params=p
 
     # Start dictionary
     StarState = {}
-    StarStateUnits = {}
 
     # Add basic input parameters
     StarState['Mstar'] = Mstar
@@ -401,7 +404,7 @@ def QuantitiesUnits(StarState=None):
 
     # If StarState was set in call to function then only include units for quantities in StarState and
     # make sure all quantities in StarState have units given (even if the quantity is dimensionless)
-    if not StarState is None:
+    if StarState is not None:
 
         # Make deep copy of StarStateUnits
         StarStateUnitsTemp = copy.deepcopy(StarStateUnits)
@@ -413,7 +416,7 @@ def QuantitiesUnits(StarState=None):
         for quantity in StarState:
 
             # Make sure it is included in list of units above
-            if not ( quantity in StarStateUnitsTemp ):
+            if quantity not in StarStateUnitsTemp:
                 raise Exception("units for "+quantity+" not included in units list")
 
             # Add to dictionary
@@ -470,19 +473,19 @@ def Lxuv(Mstar=None,Age=None,Omega=None,OmegaEnv=None,Prot=None,params=params.pa
 
     # Make sure only one rotation rate is set (add up number of set parameters)
     nSet = 0
-    if not Omega is None:
+    if Omega is not None:
         nSet += 1
-    if not OmegaEnv is None:
+    if OmegaEnv is not None:
         nSet += 1
-    if not Prot is None:
+    if Prot is not None:
         nSet += 1
     if not ( nSet == 1 ):
         raise Exception("can only set one of Omega, OmegaEnv, and Prot in call to function")
 
     # Get Omega not set
-    if not OmegaEnv is None:
+    if OmegaEnv is not None:
         Omega = OmegaEnv
-    if not Prot is None:
+    if Prot is not None:
         Omega = _Omega(Prot)
 
     # The function _Xray needs Ro, Rstar, and Lbol so make a StarState dictionary with these
@@ -1228,7 +1231,7 @@ def aOrbHZ(Mstar=None,Age=None,params=params.paramsDefault):
     b = 3.3954e-9
     c = -7.6364e-12
     d = -1.1950e-15
-    Seff = SeffSun + a*Teff + b*Teff**2.0 + c*Teff*3.0 + d*Teff**4.0
+    Seff = SeffSun + a*Teff + b*Teff**2.0 + c*Teff**3.0 + d*Teff**4.0
     aOrbHZAll['RecentVenus'] = ( Lbol / Seff )**0.5
 
     # Get Runaway Greenhouse limit
@@ -1237,7 +1240,7 @@ def aOrbHZ(Mstar=None,Age=None,params=params.paramsDefault):
     b = 1.4612e-8
     c = -7.6345e-12
     d = -1.7511e-15
-    Seff = SeffSun + a*Teff + b*Teff**2.0 + c*Teff*3.0 + d*Teff**4.0
+    Seff = SeffSun + a*Teff + b*Teff**2.0 + c*Teff**3.0 + d*Teff**4.0
     aOrbHZAll['RunawayGreenhouse'] = ( Lbol / Seff )**0.5
 
     # Get Moist Greenhouse limit
@@ -1246,7 +1249,7 @@ def aOrbHZ(Mstar=None,Age=None,params=params.paramsDefault):
     b = 1.9394e-9
     c = -4.3618e-12
     d = -6.8260e-16
-    Seff = SeffSun + a*Teff + b*Teff**2.0 + c*Teff*3.0 + d*Teff**4.0
+    Seff = SeffSun + a*Teff + b*Teff**2.0 + c*Teff**3.0 + d*Teff**4.0
     aOrbHZAll['MoistGreenhouse'] = ( Lbol / Seff )**0.5
 
     # Get Maximum Greenhouse limit
@@ -1255,7 +1258,7 @@ def aOrbHZ(Mstar=None,Age=None,params=params.paramsDefault):
     b = 1.6707e-9
     c = -3.0058e-12
     d = -5.1925e-16
-    Seff = SeffSun + a*Teff + b*Teff**2.0 + c*Teff*3.0 + d*Teff**4.0
+    Seff = SeffSun + a*Teff + b*Teff**2.0 + c*Teff**3.0 + d*Teff**4.0
     aOrbHZAll['MaximumGreenhouse'] = ( Lbol / Seff )**0.5
 
     # Get Early Mars limit
@@ -1264,7 +1267,7 @@ def aOrbHZ(Mstar=None,Age=None,params=params.paramsDefault):
     b = 1.5275e-9
     c = -2.1709e-12
     d = -3.8282e-16
-    Seff = SeffSun + a*Teff + b*Teff**2.0 + c*Teff*3.0 + d*Teff**4.0
+    Seff = SeffSun + a*Teff + b*Teff**2.0 + c*Teff**3.0 + d*Teff**4.0
     aOrbHZAll['EarlyMars'] = ( Lbol / Seff )**0.5
 
     # Now get value of center of moist and maximum greenhouse

--- a/src/mors/rotevo.py
+++ b/src/mors/rotevo.py
@@ -1,20 +1,20 @@
 
-"""Module for holding functions used to evovle the rotation of stars."""
+"""Module for holding functions used to evolve the rotation of stars."""
 
-# Imports for standard stuff needed here
-import numpy as np
-import math
+from __future__ import annotations
+
 import copy
-
 import logging
-log = logging.getLogger("fwl."+__name__)
+import math
 
-# Imports for mors modules
+import numpy as np
+
 import mors.miscellaneous as misc
-import mors.physicalmodel as phys
 import mors.parameters as params
+import mors.physicalmodel as phys
 import mors.stellarevo as SE
-import sys
+
+log = logging.getLogger("fwl." + __name__)
 
 AgeMinDefault = 1.0       # when to start evolution (Myr)
 AgeMaxDefault = 5000.0    # when to end evolution (Myr)
@@ -195,7 +195,7 @@ def EvolveRotation(Mstar=None,Omega0=None,OmegaEnv0=None,OmegaCore0=None,AgeMin=
         AgeMax = params['AgeMaxDefault']
 
     # Make editable and np array form of AgesOut and use this from now on
-    if not AgesOut is None:
+    if AgesOut is not None:
         if isinstance(AgesOut,(float,int)):
             AgesOut2 = np.array([AgesOut])
         else:
@@ -204,7 +204,7 @@ def EvolveRotation(Mstar=None,Omega0=None,OmegaEnv0=None,OmegaCore0=None,AgeMin=
         AgesOut2 = None
 
     # If AgesOut has been set, use the final age from that as ending age
-    if not AgesOut2 is None:
+    if AgesOut2 is not None:
         AgeMax = AgesOut2[-1]
 
     # If an instance of the StarEvo class is not input, load it with defaults
@@ -222,7 +222,7 @@ def EvolveRotation(Mstar=None,Omega0=None,OmegaEnv0=None,OmegaCore0=None,AgeMin=
     dAge = 0.5
 
     # If AgesOut was set, make sure no ages are below AgeMin
-    if not AgesOut2 is None:
+    if AgesOut2 is not None:
         AgesOut2 = np.delete( AgesOut2 , np.where(AgesOut2<AgeMin) )
 
     # Starting rotation rates
@@ -282,7 +282,7 @@ def _dAgeCalc(dAge,Age,AgeMax,AgesOut,params):
     dAgeMax = AgeMax - Age
 
     # If AgesOut has been set, work out maximum from that
-    if not AgesOut is None:
+    if AgesOut is not None:
 
         # If AgesOut is just a number (float or int) then it is easy
         if isinstance(AgesOut,(float,int)):
@@ -315,13 +315,15 @@ def _shouldAppend(Age,AgesOut):
         return AgesOut , True
 
     # If AgesOut is set, work out if this is one of the output ages
-    if not AgesOut is None:
+    if AgesOut is not None:
 
         # If AgesOut is just a number (float or int) then it is easy
         if isinstance(AgesOut,(float,int)):
 
-            # Check if close enough to AgesOut to output
-            if ( abs(Age/float(AgesOut))-1.0 < 1.0e-6 ):
+            # Check if close enough to AgesOut to output. The relative distance
+            # abs(Age/AgesOut - 1) is compared to the tolerance, so only ages
+            # within 1e-6 of AgesOut are emitted, not every age up to AgesOut.
+            if ( abs(Age/float(AgesOut) - 1.0) < 1.0e-6 ):
                 return AgesOut , True
             else:
                 return AgesOut , False
@@ -814,7 +816,7 @@ def _AppendTracks(Tracks,Mstar,Age,dAge,OmegaEnv,OmegaCore,params,StarEvo,StarSt
         for quantity in StarState:
 
             # Do not do quantity if it was already added above
-            if not ( quantity in ['Age','dAge','OmegaEnv','OmegaCore'] ):
+            if quantity not in ['Age','dAge','OmegaEnv','OmegaCore']:
                 Tracks[quantity] = np.append( Tracks[quantity] , StarState[quantity] )
 
     return Tracks

--- a/src/mors/star.py
+++ b/src/mors/star.py
@@ -1,21 +1,23 @@
 
 """Module holding the Star class and related functions."""
 
+from __future__ import annotations
+
 # Imports for standard stuff needed here
-import sys
-import inspect
-import numpy as np
+import copy
+import logging
 import pickle
 
-import logging
-log = logging.getLogger("fwl."+__name__)
+import numpy as np
 
-# Imports for nors modules
+# Imports for mors modules
 import mors.miscellaneous as misc
-import mors.stellarevo as SE
 import mors.parameters as params
-import mors.rotevo as RE
 import mors.physicalmodel as phys
+import mors.rotevo as RE
+import mors.stellarevo as SE
+
+log = logging.getLogger("fwl." + __name__)
 
 # Limits on various input values
 MstarMin = 0.1
@@ -31,17 +33,17 @@ class Star:
         """Initialises instance of Star class.
 
         This is the main function that is run when creating an instance of the Star class and it sets up all
-        the things needed including calculating evolutionary tracks for the star. 
-        
+        the things needed including calculating evolutionary tracks for the star.
+
         The function requires that the arguments Mstar (the star's mass in Msun) and Omega (in OmegaSun=2.67e-6 rad s^-1) are specified
         in the call. Alternatively, OmegaEnv and OmegaCore can be set, in which case Omega does not need to
         be specified. If the argument Age (in Myr) is also specified, then the code will find the evolutionary
         track that passes through this rotation rate at this age, otherwise if Age is not set then it will
-        calculate evolutionary tracks assuming this Omega as the initial (1 Myr) rotation rate. 
-        
+        calculate evolutionary tracks assuming this Omega as the initial (1 Myr) rotation rate.
+
         The user should not specify OmegaCore and Age simultaneously, and if Age is set then either Omega or OmegaEnv can be
-        used to specify the surface rotation rate. 
-        
+        used to specify the surface rotation rate.
+
         The user can also specify the initial rotation rate using using a percentile of the 1 Myr rotation distribution via the ``percentile`` keyword argument.
 
         Parameters
@@ -78,8 +80,10 @@ class Star:
         # (if Omega is set, OmegaEnv and OmegaCore will both be set to that value)
         Omega , OmegaEnv , OmegaCore = _InputRotation(Mstar,Age,Omega,OmegaEnv,OmegaCore,Prot,percentile,params)
 
-        # Set parameters
-        self.params = params
+        # Set parameters. Copy the passed dictionary so enabling ExtendedTracks
+        # below stays local to this star and does not mutate the shared default
+        # dictionary that other stars read from.
+        self.params = copy.deepcopy(params)
 
         # Set the ExtendedTracks parameter to True so we get all parameters
         self.params['ExtendedTracks'] = True
@@ -124,7 +128,7 @@ class Star:
         self.AgeMax = self.StarEvo.ModelData[self.Mstar]['Age'][-1]
 
         # If needing to get initial rotation rate then get it
-        if not Age is None:
+        if Age is not None:
 
             # Get initial rotation
             Omega0 = RE.FitRotation( Mstar=self.Mstar , Age=Age , Omega=OmegaEnv0 ,
@@ -351,7 +355,7 @@ class Star:
         def nAge(self,Age):
             return self.Value(Age=Age, Quantity="nAge")
         setattr(self.__class__, "nAge", nAge)
-        
+
         return
 
     def Value(self,Age=None,Quantity=None):
@@ -374,7 +378,7 @@ class Star:
             raise Exception("Quantity must be string")
 
         # Make sure Quantity is a valid quantity with a track
-        if not Quantity in self.Tracks:
+        if Quantity not in self.Tracks:
             raise Exception("no available track for "+Quantity)
 
         return self.Tracks[Quantity]
@@ -455,7 +459,7 @@ class Star:
             raise Exception("Quantity must be string")
 
         # Check input Quantity is valid
-        if not Quantity in QuantitiesAllowed:
+        if Quantity not in QuantitiesAllowed:
             QuantitiesString = ''
             for quantity in QuantitiesAllowed:
                 QuantitiesString += quantity + " , "
@@ -522,7 +526,7 @@ class Star:
             raise Exception("Band must be string")
 
         # Check input Band is valid
-        if not Band in BandsAllowed:
+        if Band not in BandsAllowed:
             BandsString = ''
             for band in BandsAllowed:
                 BandsString += band + " , "
@@ -553,7 +557,7 @@ class Star:
             aOrbAllowed = [ 'RecentVenus' , 'RunawayGreenhouse' , 'MoistGreenhouse' , 'MaximumGreenhouse' , 'EarlyMars' , 'HZ' ]
 
             # Check input is valid
-            if not aOrb in aOrbAllowed:
+            if aOrb not in aOrbAllowed:
                 aOrbString = ''
                 for a in aOrbAllowed:
                     aOrbString += a + " , "
@@ -597,18 +601,18 @@ def _InputRotation(Mstar,Age,Omega,OmegaEnv,OmegaCore,Prot,percentile,params):
     """Takes input rotation values, checks sets up values correctly."""
 
     # Make sure percentile and rotation are not both set
-    if not percentile is None:
-        if not Omega is None :
+    if percentile is not None:
+        if Omega is not None :
             raise Exception( "cannot set both percentile and Omega as arguments of Star" )
-        if not OmegaEnv is None :
+        if OmegaEnv is not None :
             raise Exception( "cannot set both percentile and OmegaEnv as arguments of Star" )
-        if not OmegaCore is None :
+        if OmegaCore is not None :
             raise Exception( "cannot set both percentile and OmegaCore as arguments of Star" )
-        if not Prot is None :
+        if Prot is not None :
             raise Exception( "cannot set both percentile and Prot as arguments of Star" )
 
     # Make sure percentile and OmegaEnv are not both set
-    if ( not percentile is None ) and ( not OmegaEnv is None ):
+    if ( percentile is not None ) and ( OmegaEnv is not None ):
         raise Exception( "cannot set both percentile and OmegaEnv as arguments of Star" )
 
     # If percentile was set to a string, get float version
@@ -623,26 +627,26 @@ def _InputRotation(Mstar,Age,Omega,OmegaEnv,OmegaCore,Prot,percentile,params):
             raise Exception( "invalid percentile string (options are 'slow', 'medium', or 'fast')" )
 
     # If percentile was set, get Omega
-    if not percentile is None:
+    if percentile is not None:
         Omega = Percentile(Mstar=Mstar,percentile=percentile,params=params)
 
     # Make sure if Age is set that OmegaCore is not set
-    if ( not Age is None ) and ( not OmegaCore is None ):
+    if ( Age is not None ) and ( OmegaCore is not None ):
         raise Exception( "cannot set both Age and OmegaCore as arguments of Star" )
 
     # Make sure not both Omega and Prot were set
-    if ( not Omega is None ) and ( not Prot is None ):
+    if ( Omega is not None ) and ( Prot is not None ):
         raise Exception( "cannot set both Omega and Prot as arguments of Star" )
 
     # If Prot is set, get Omega
-    if not Prot is None:
+    if Prot is not None:
         Omega = phys._Omega(Prot)
 
     # Make sure at least one rotation rate is set
     if ( Omega is None ):
 
         # If Age is set then make sure OmegaEnv is set, otherwise make sure both OmegaEnv and OmegaCore are set
-        if ( not Age is None ):
+        if ( Age is not None ):
             if ( OmegaEnv is None ):
                 raise Exception( "if Age is set then must set either Omega or OmegaEnv as argument of Star" )
         elif ( OmegaEnv is None ) or ( OmegaCore is None ):
@@ -706,8 +710,8 @@ def Percentile(Mstar=None,Omega=None,Prot=None,percentile=None,MstarDist=None,Om
     # If percentile is not set, make sure rotation rate is set
     if percentile is None:
         # Not both
-        if not Omega is None:
-            if not Prot is None:
+        if Omega is not None:
+            if Prot is not None:
                 raise Exception( "keyword arguments Omega and Prot cannot both be set" )
         # At least one
         if ( Omega is None ) and ( Prot is None ):
@@ -726,19 +730,19 @@ def Percentile(Mstar=None,Omega=None,Prot=None,percentile=None,MstarDist=None,Om
             raise Exception( "one of keyword arguments OmegaDist and ProtDist must be set" )
 
         # Check that OmegaDist and ProtDist are not both set
-        if ( not OmegaDist is None ) and ( not ProtDist is None ):
+        if ( OmegaDist is not None ) and ( ProtDist is not None ):
             raise Exception( "keyword arguments OmegaDist and ProtDist cannot both be set" )
 
         # Setup OmegaDist if ProtDist was set
         if OmegaDist is None:
-            OmegaDist = misc._Omega(ProtDist)
+            OmegaDist = phys._Omega(ProtDist)
 
         # Make sure arrays are same length
         if not ( len(MstarDist) == len(OmegaDist) ):
             raise Exception( "MstarDist and OmegaDist (or ProtDist) must be same length" )
 
     # Work out which one to do
-    if not percentile is None:
+    if percentile is not None:
 
         # percentile was set, so get corresponding rotation rates
         result = _OmegaPercentile(Mstar,percentile,MstarDist,OmegaDist,params)
@@ -811,4 +815,3 @@ def _PerPercentile(Mstar,Omega,MstarDist,OmegaDist,params):
     # If we get here, not converged
     raise Exception(
         f"did not find percentile for Omega={Omega} (Mstar={Mstar}) after {nIterMax} iterations; last bracket=({perMin},{perMax}), last mid={perMid}")
-

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -33,6 +33,8 @@ import numpy as np
 import pytest
 from numpy.testing import assert_allclose
 
+from mors import parameters
+
 pytestmark = [pytest.mark.unit, pytest.mark.timeout(30)]
 
 
@@ -140,6 +142,31 @@ def test_construction_populates_stars_and_hz_boundaries(cluster_mod):
     # Habitable-zone boundaries are strictly positive distances (AU).
     assert np.all(cluster.aOrbHZ['HZ'] > 0.0)
     assert np.all(cluster.aOrbHZ['RunawayGreenhouse'] > 0.0)
+
+
+def test_construction_copies_params_and_leaves_shared_default_intact(cluster_mod):
+    """Building a cluster copies its parameters rather than writing the shared default.
+
+    A cluster enables ``ExtendedTracks`` so the per-star model returns every
+    auxiliary quantity. That write must land on a private copy: the module-level
+    ``paramsDefault`` (the default argument shared by every entry point) has to
+    stay off, and a caller-supplied dictionary must be left as it was passed. If
+    the parameters were aliased instead of copied, the first cluster would flip
+    the flag globally and every later star would silently switch tracks.
+    """
+    # The shared default advertises ExtendedTracks off; constructing from it
+    # must not flip that global for later callers.
+    assert parameters.paramsDefault['ExtendedTracks'] is False
+    cluster = make_cluster(cluster_mod, n=3)
+    assert parameters.paramsDefault['ExtendedTracks'] is False
+    # The cluster works on an independent copy that carries the enabled flag.
+    assert cluster.params is not parameters.paramsDefault
+    assert cluster.params['ExtendedTracks'] is True
+    # A caller-supplied dictionary is copied too, not aliased and mutated.
+    user_params = dict(parameters.paramsDefault)
+    cluster_user = make_cluster(cluster_mod, n=3, params=user_params)
+    assert user_params['ExtendedTracks'] is False
+    assert cluster_user.params['ExtendedTracks'] is True
 
 
 def test_values_returns_per_star_array_and_requires_arguments(cluster_mod):

--- a/tests/test_physicalmodel.py
+++ b/tests/test_physicalmodel.py
@@ -895,6 +895,37 @@ class TestHabitableZone:
         # Sign / scale guard: a solar inner HZ edge is near 1 AU, not 0.1 or 10 AU.
         assert 0.5 < hz['RunawayGreenhouse'] < 1.5
 
+    @pytest.mark.reference_pinned
+    @pytest.mark.physics_invariant
+    def test_runaway_greenhouse_limit_for_a_cool_star(self, monkeypatch):
+        """For a cool star the runaway greenhouse limit follows the Kopparapu polynomial.
+
+        Reference: Kopparapu et al. (2013), Table 3. At Teff = 4000 K the shifted
+        temperature Tstar = Teff - 5780 = -1780 K drives the full
+        a*Tstar + b*Tstar**2 + c*Tstar**3 + d*Tstar**4 correction, unlike the
+        solar case where every temperature term vanishes. The boundary distance
+        is (Lbol / Seff)**0.5 with Seff from the published coefficients.
+        """
+        monkeypatch.setattr('mors.stellarevo.Lbol', lambda M, A: 0.1)
+        monkeypatch.setattr('mors.stellarevo.Teff', lambda M, A: 4000.0)
+        hz = pm.aOrbHZ(Mstar=0.5, Age=1000.0)
+        # Kopparapu runaway-greenhouse coefficients at Tstar = -1780 K.
+        tstar = 4000.0 - 5780.0
+        seff = (1.0385 + 1.2456e-4 * tstar + 1.4612e-8 * tstar**2
+                - 7.6345e-12 * tstar**3 - 1.7511e-15 * tstar**4)
+        expected = (0.1 / seff) ** 0.5
+        assert_allclose(hz['RunawayGreenhouse'], expected, rtol=1e-9)
+        # Discrimination guard: a linear cubic term (c*Tstar instead of
+        # c*Tstar**3) shifts the boundary by more than two percent at this
+        # temperature, so an exponent slip fails here even though it is invisible
+        # at the solar anchor where Tstar is zero.
+        seff_linear = (1.0385 + 1.2456e-4 * tstar + 1.4612e-8 * tstar**2
+                       - 7.6345e-12 * tstar * 3.0 - 1.7511e-15 * tstar**4)
+        wrong = (0.1 / seff_linear) ** 0.5
+        assert abs(hz['RunawayGreenhouse'] - wrong) > 0.02 * expected
+        # Positivity and scale guard for a cool, faint star.
+        assert 0.2 < hz['RunawayGreenhouse'] < 0.5
+
     @pytest.mark.physics_invariant
     def test_habitable_zone_boundaries_are_ordered(self, monkeypatch):
         """The habitable-zone boundaries increase from the hottest to the coolest limit.

--- a/tests/test_rotevo.py
+++ b/tests/test_rotevo.py
@@ -154,28 +154,30 @@ def test_shouldappend_no_output_list_always_true():
     assert returned is None
 
 
-def test_shouldappend_scalar_pins_present_behaviour():
-    """Pins the present scalar-branch behaviour of the output-cadence check.
+def test_shouldappend_scalar_proximity_contract():
+    """The scalar output-cadence check flags only ages within the relative tolerance.
 
-    This does NOT assert a proximity contract. The scalar branch evaluates
-    ``abs(Age / AgesOut) - 1.0 < 1e-6`` (operator precedence groups the
-    subtraction before the comparison), so it flags any Age at or below the
-    target rather than only ages within 1e-6 of it, and rejects an Age that
-    overshoots the target by more than a factor of ~1e-6. The assertions below
-    record that actual behaviour; see the flagged source bug for the intended
-    proximity form.
+    The scalar branch emits an age when ``abs(Age / AgesOut - 1) < 1e-6``, i.e.
+    only when Age lies within one part in 1e6 of the target output age. Ages away
+    from the target on either side are rejected, so the branch is a genuine
+    two-sided proximity test rather than a one-sided "at or below" filter.
     """
-    # Age well below the target: the present branch flags it True even though it
-    # is nowhere near the target, which is the non-proximity behaviour.
-    _, flag_far_below = rotevo._shouldAppend(5.0, 10.0)
-    # Age above the target by more than the ~1e-6 margin: rejected.
-    _, flag_above = rotevo._shouldAppend(10.0, 5.0)
-    assert flag_far_below is True
-    assert flag_above is False
-    # A genuine proximity check would reject an Age three orders of magnitude
-    # below the target; the present branch flags it, confirming it is not one.
+    target = 10.0
+    # Exact hit and a hit just inside the 1e-6 relative window are flagged.
+    _, flag_exact = rotevo._shouldAppend(target, target)
+    _, flag_inside = rotevo._shouldAppend(target * (1.0 + 5.0e-7), target)
+    assert flag_exact is True
+    assert flag_inside is True
+    # An age at half the target, and one three orders of magnitude below it, are
+    # both far outside the window and rejected: the check is not "at or below".
+    _, flag_half = rotevo._shouldAppend(0.5 * target, target)
     _, flag_tiny = rotevo._shouldAppend(1.0, 1.0e3)
-    assert flag_tiny is True
+    assert flag_half is False
+    assert flag_tiny is False
+    # An age just outside the window on the high side is rejected too, so the
+    # tolerance is symmetric about the target rather than one-sided.
+    _, flag_outside = rotevo._shouldAppend(target * (1.0 + 2.0e-6), target)
+    assert flag_outside is False
 
 
 def test_shouldappend_array_hit_removes_element():

--- a/tests/test_star.py
+++ b/tests/test_star.py
@@ -70,6 +70,25 @@ def test_star_reproduces_solar_luminosity_at_solar_age():
     assert faint < 0.1 * lbol
 
 
+def test_star_construction_leaves_shared_default_params_intact():
+    """Constructing a star copies its parameters rather than writing the shared default.
+
+    ``Star`` enables ``ExtendedTracks`` on its own parameter dictionary so every
+    evolved quantity is retained. That write must land on a private copy: the
+    module-level ``paramsDefault`` shared by every entry point stays off, while
+    the star's own copy carries the enabled flag. Aliasing instead of copying
+    would flip the global for every star built afterwards.
+    """
+    mors.DownloadEvolutionTracks('Spada')
+    # Pristine shared default: ExtendedTracks off before any construction.
+    assert paramsDefault['ExtendedTracks'] is False
+    star = mors.Star(Mstar=1.0, Omega=1.0)
+    # The shared default is untouched; only the star's private copy is enabled.
+    assert paramsDefault['ExtendedTracks'] is False
+    assert star.params is not paramsDefault
+    assert star.params['ExtendedTracks'] is True
+
+
 @pytest.mark.physics_invariant
 @pytest.mark.parametrize('inp,expected', SPADA_DEFAULT)
 def test_star_value_default_integrator(inp, expected):
@@ -123,22 +142,89 @@ def test_star_value_forward_euler_integrator(inp, expected):
 # than time series, so their getter raises when the 1D interpolator indexes them.
 SCALAR_TRACK_GETTERS = ('Mstar', 'nAge')
 ARRAY_TRACK_GETTERS = (
-    'Age', 'dAge', 'OmegaEnv', 'OmegaCore', 'Prot', 'Rstar', 'tauConv', 'Ro',
-    'Itotal', 'Ienv', 'Icore', 'dItotaldt', 'dIenvdt', 'dIcoredt', 'Rcore',
-    'dMcoredt', 'Mdot', 'Bdip', 'vEsc', 'torqueEnvMom', 'torqueCoreMom',
-    'torqueEnvCG', 'torqueCoreCG', 'torqueEnvWind', 'torqueEnvCE', 'torqueCoreCE',
-    'torqueEnvDL', 'torqueEnv', 'dOmegaEnvdt', 'torqueCore', 'dOmegaCoredt',
-    'Lbol', 'Teff', 'Lx', 'Fx', 'Rx', 'Tcor', 'Leuv1', 'Feuv1', 'Reuv1',
-    'Leuv2', 'Feuv2', 'Reuv2', 'Leuv', 'Feuv', 'Reuv', 'Lly', 'Fly', 'Rly',
-    'FxHZ', 'Feuv1HZ', 'Feuv2HZ', 'FeuvHZ', 'FlyHZ',
+    'Age',
+    'dAge',
+    'OmegaEnv',
+    'OmegaCore',
+    'Prot',
+    'Rstar',
+    'tauConv',
+    'Ro',
+    'Itotal',
+    'Ienv',
+    'Icore',
+    'dItotaldt',
+    'dIenvdt',
+    'dIcoredt',
+    'Rcore',
+    'dMcoredt',
+    'Mdot',
+    'Bdip',
+    'vEsc',
+    'torqueEnvMom',
+    'torqueCoreMom',
+    'torqueEnvCG',
+    'torqueCoreCG',
+    'torqueEnvWind',
+    'torqueEnvCE',
+    'torqueCoreCE',
+    'torqueEnvDL',
+    'torqueEnv',
+    'dOmegaEnvdt',
+    'torqueCore',
+    'dOmegaCoredt',
+    'Lbol',
+    'Teff',
+    'Lx',
+    'Fx',
+    'Rx',
+    'Tcor',
+    'Leuv1',
+    'Feuv1',
+    'Reuv1',
+    'Leuv2',
+    'Feuv2',
+    'Reuv2',
+    'Leuv',
+    'Feuv',
+    'Reuv',
+    'Lly',
+    'Fly',
+    'Rly',
+    'FxHZ',
+    'Feuv1HZ',
+    'Feuv2HZ',
+    'FeuvHZ',
+    'FlyHZ',
 )
 # Quantities that are strictly positive by physical construction at every age: a
 # whole-star radius, temperature, rotation rate, or an emitted power can never be
 # zero or negative for an active star.
 STRICTLY_POSITIVE_GETTERS = (
-    'Age', 'OmegaEnv', 'OmegaCore', 'Prot', 'Rstar', 'tauConv', 'Ro', 'Itotal',
-    'Ienv', 'vEsc', 'Bdip', 'Lbol', 'Teff', 'Lx', 'Fx', 'Rx',
-    'Leuv1', 'Feuv1', 'Leuv2', 'Feuv2', 'Leuv', 'Feuv', 'Lly', 'Fly',
+    'Age',
+    'OmegaEnv',
+    'OmegaCore',
+    'Prot',
+    'Rstar',
+    'tauConv',
+    'Ro',
+    'Itotal',
+    'Ienv',
+    'vEsc',
+    'Bdip',
+    'Lbol',
+    'Teff',
+    'Lx',
+    'Fx',
+    'Rx',
+    'Leuv1',
+    'Feuv1',
+    'Leuv2',
+    'Feuv2',
+    'Leuv',
+    'Feuv',
+    'Lly',
+    'Fly',
 )
 # The radiative core has not formed at 1 Myr (the star is fully convective), so
 # its moment of inertia and radius start at zero and grow positive as the star
@@ -280,9 +366,7 @@ def test_activity_lifetime_decreases_with_threshold(solar_star):
     life_sat = solar_star.ActivityLifetime(Quantity='Lx', Threshold='sat')
     assert life_sat > 0.0
     # AgeMax caps the search window; the answer cannot exceed the cap.
-    life_capped = solar_star.ActivityLifetime(
-        Quantity='Lx', Threshold=1.0e27, AgeMax=500.0
-    )
+    life_capped = solar_star.ActivityLifetime(Quantity='Lx', Threshold=1.0e27, AgeMax=500.0)
     assert life_capped <= 500.0 + 1.0e-6
 
 
@@ -361,9 +445,7 @@ def test_integrated_emission_validates_band_and_orbit(solar_star):
     with pytest.raises(Exception, match='invalid Band'):
         solar_star.IntegrateEmission(AgeMin=100.0, AgeMax=1000.0, Band='Gamma')
     with pytest.raises(Exception, match='invalid aOrb'):
-        solar_star.IntegrateEmission(
-            AgeMin=100.0, AgeMax=1000.0, Band='XUV', aOrb='NoSuchZone'
-        )
+        solar_star.IntegrateEmission(AgeMin=100.0, AgeMax=1000.0, Band='XUV', aOrb='NoSuchZone')
 
 
 @pytest.mark.physics_invariant
@@ -440,8 +522,14 @@ def test_check_input_mstar_enforces_grid_bounds():
 def _input_rotation(**overrides):
     """Call ``_InputRotation`` with all-None defaults, overriding named arguments."""
     base = dict(
-        Mstar=1.0, Age=None, Omega=None, OmegaEnv=None, OmegaCore=None,
-        Prot=None, percentile=None, params=dict(paramsDefault),
+        Mstar=1.0,
+        Age=None,
+        Omega=None,
+        OmegaEnv=None,
+        OmegaCore=None,
+        Prot=None,
+        percentile=None,
+        params=dict(paramsDefault),
     )
     base.update(overrides)
     return star_mod._InputRotation(**base)
@@ -462,9 +550,16 @@ def _input_rotation(**overrides):
         ({'Omega': 1.0, 'OmegaEnv': 1.0}, 'cannot set OmegaEnv and OmegaCore'),
     ],
     ids=[
-        'pct-and-omega', 'pct-and-omegaenv', 'pct-and-omegacore', 'pct-and-prot',
-        'bad-percentile-string', 'age-and-omegacore', 'omega-and-prot',
-        'age-without-omegaenv', 'nothing-set', 'omega-with-envcore',
+        'pct-and-omega',
+        'pct-and-omegaenv',
+        'pct-and-omegacore',
+        'pct-and-prot',
+        'bad-percentile-string',
+        'age-and-omegacore',
+        'omega-and-prot',
+        'age-without-omegaenv',
+        'nothing-set',
+        'omega-with-envcore',
     ],
 )
 def test_input_rotation_rejects_conflicting_arguments(overrides, match):
@@ -528,13 +623,18 @@ def test_percentile_validates_supplied_distribution():
         mors.Percentile(Mstar=1.0, Omega=1.0, MstarDist=md)
     with pytest.raises(Exception, match='cannot both be set'):
         mors.Percentile(
-            Mstar=1.0, Omega=1.0, MstarDist=md,
-            OmegaDist=np.array([1.0, 2.0]), ProtDist=np.array([10.0, 20.0]),
+            Mstar=1.0,
+            Omega=1.0,
+            MstarDist=md,
+            OmegaDist=np.array([1.0, 2.0]),
+            ProtDist=np.array([10.0, 20.0]),
         )
     with pytest.raises(Exception, match='same length'):
         mors.Percentile(
-            Mstar=1.0, Omega=1.0,
-            MstarDist=np.array([1.0, 1.0, 1.0]), OmegaDist=np.array([1.0, 2.0]),
+            Mstar=1.0,
+            Omega=1.0,
+            MstarDist=np.array([1.0, 1.0, 1.0]),
+            OmegaDist=np.array([1.0, 2.0]),
         )
 
 
@@ -559,25 +659,39 @@ def test_percentile_inverts_rotation_and_percentile():
     assert 0.0 <= pct_from_prot <= 100.0
 
 
-def test_percentile_protdist_conversion_unavailable():
-    """Supplying only ``ProtDist`` surfaces the missing period-to-rate helper.
+@pytest.mark.physics_invariant
+def test_percentile_from_period_distribution_matches_rate_distribution():
+    """A rotation-period distribution gives the same percentile as its rate form.
 
-    The period-distribution branch calls ``misc._Omega`` to convert periods to
-    rotation rates, but no such helper exists on the miscellaneous module, so the
-    call raises rather than returning a silently wrong rotation distribution.
+    The period-distribution branch converts each period to a rotation rate with
+    the standard period-to-rate relation, so a percentile computed from a
+    ``ProtDist`` must equal the percentile computed from the ``OmegaDist`` that
+    the same periods map to. Supplying both distributions at once is rejected.
     """
+    from mors import physicalmodel as phys
+
     md = np.array([1.0, 1.0])
-    pd = np.array([10.0, 20.0])
-    # This pins the present behaviour of the ProtDist branch: it references a
-    # helper that is not defined, so it raises instead of building a distribution.
-    with pytest.raises(AttributeError):
-        mors.Percentile(Mstar=1.0, percentile=50.0, MstarDist=md, ProtDist=pd)
-    # The equivalent rate-distribution path is well-defined and returns a value
-    # inside the physical rotation range, confirming only the period branch is out.
-    omega = mors.Percentile(
-        Mstar=1.0, percentile=50.0, MstarDist=md, OmegaDist=np.array([2.0, 4.0])
+    prot = np.array([10.0, 20.0])
+    omega_from_prot = mors.Percentile(Mstar=1.0, percentile=50.0, MstarDist=md, ProtDist=prot)
+    omega_from_rate = mors.Percentile(
+        Mstar=1.0, percentile=50.0, MstarDist=md, OmegaDist=phys._Omega(prot)
     )
-    assert omega == pytest.approx(3.0, rel=1e-6)
+    assert_allclose(omega_from_prot, omega_from_rate, rtol=1e-12)
+    # The percentile is a physical rotation rate inside the range the periods
+    # map to, so the conversion cannot have collapsed to a constant or a stray
+    # index. A shorter period maps to a faster rate, so _Omega is decreasing.
+    rates = phys._Omega(prot)
+    assert rates[0] > rates[1] > 0.0
+    assert min(rates) <= omega_from_prot <= max(rates)
+    # Setting both distributions at once violates the error contract.
+    with pytest.raises(Exception, match='cannot both be set'):
+        mors.Percentile(
+            Mstar=1.0,
+            percentile=50.0,
+            MstarDist=md,
+            OmegaDist=np.array([2.0, 4.0]),
+            ProtDist=prot,
+        )
 
 
 @pytest.mark.physics_invariant


### PR DESCRIPTION
This fixes five pre-existing bugs in the MORS source, each with a test that fails against the old code and passes against the new. The only one that changes physical output is the habitable-zone cubic term, which was written as a linear term and so gave wrong boundary distances for every non-solar star. The other four are a shared-parameter aliasing bug that made construction order affect results, a broken rotation-period-distribution input, a one-sided proximity check in an unreachable branch, and a malformed error message.

I kept the earlier test-coverage change test-centred and left these fixes for this focused follow-up. None of the five sits in a code path that PROTEUS exercises, so PROTEUS compatibility is retained (verified end to end, see Testing).

## Why

The habitable-zone boundaries were wrong for any star other than the Sun, which is the one fix here that changes a physical result. The parameter-aliasing bug let the first star or cluster built in a process silently change the defaults every later object reads. The remaining three are latent correctness issues in code paths that are not currently exercised, fixed now so they do not surprise a future caller.

## The bugs, in detail

**1. Habitable-zone cubic term (`physicalmodel.py`, `aOrbHZ`).** The five Kopparapu et al. (2013) boundary blocks wrote the cubic term as `c*Teff*3.0` instead of `c*Teff**3.0`. The variable named `Teff` here actually holds `Tstar = Teff - 5780`, so the intended term is `c * Tstar**3`. Written as `c * Tstar * 3` the cubic contribution collapses to a scaled linear one, so every boundary comes out wrong for any non-solar star. At the Sun the shifted temperature is exactly zero and both forms vanish, which is why it stayed hidden. Measured effect on the boundary distance `aOrb = (Lbol/Seff)**0.5` for the Runaway Greenhouse limit: 0.0% at `Teff = 5780 K`, about -2.5% at 4000 K, and about -7.9% at 3200 K. Fix: change `c*Teff*3.0` to `c*Teff**3.0` in all five blocks. A reference-pinned test pins the Runaway Greenhouse boundary for a 4000 K star to the Kopparapu closed form and carries a discrimination guard showing the linear-collapse value differs by more than the tolerance.

**2. Shared default-parameter mutation (`star.py`, `cluster.py`).** `Star.__init__` and `Cluster.__init__` took `params=paramsDefault` as a default argument, aliased it with `self.params = params`, then set `self.params['ExtendedTracks'] = True` in place. Because `paramsDefault` is a single shared module-level dictionary, the first `Star` or `Cluster` built in a process permanently flipped `ExtendedTracks` in the default that every later object reads, so the behaviour depended on construction order. The physics of any single star was correct; the leak was in the shared default. Fix: copy the dictionary before mutating it, `self.params = copy.deepcopy(params)`, in both constructors. Tests assert that constructing a `Star` or a `Cluster` leaves `paramsDefault` unchanged while the object's own copy carries the enabled flag, and that a caller-supplied dictionary is copied rather than aliased.

**3. Rotation-period-distribution input (`star.py`, `Percentile`).** The period-distribution branch called `misc._Omega(ProtDist)` to convert a supplied rotation-period distribution to rotation rates, but the helper lives in `physicalmodel`, not `miscellaneous`, so passing a `ProtDist` raised `AttributeError`. Fix: call the existing `phys._Omega`, the standard period-to-rate conversion already used for the scalar `Prot` input. A test asserts that a percentile computed from a `ProtDist` equals the percentile computed from the equivalent `OmegaDist`, and that supplying both distributions at once still raises.

**4. Rotation-output cadence check (`rotevo.py`, `_shouldAppend`).** The scalar branch wrote `abs(Age/float(AgesOut))-1.0 < 1.0e-6`, which by operator precedence is `(abs(Age/AgesOut) - 1.0) < 1e-6`, a one-sided "not far above the target" test rather than the intended two-sided proximity test. This branch is not reached in normal use: `EvolveRotation` normalises a scalar `AgesOut` to a one-element array before the integration loop, so the scalar branch is reachable only by calling `_shouldAppend` directly. Fix: move the closing parenthesis inside `abs(...)` so the test is `abs(Age/float(AgesOut) - 1.0) < 1.0e-6`. The updated test asserts the two-sided proximity contract (ages on either side of the target outside the tolerance are rejected).

**5. Baraffe missing-file message (`baraffe.py`).** The `IOError` raised when a track file is absent used a plain string that contained `{path}` but was not an f-string, so the message printed the literal `{path}` instead of the file path, and it named a `mors dowload` command that does not exist. Fix: make the string an f-string and point at the real `mors download baraffe` command.

## PROTEUS compatibility

None of these fixes changes a code path PROTEUS exercises:

- PROTEUS drives rotation through `mors.Star(..., percentile=..., Prot=...)` with a percentile and a scalar rotation period, never a period distribution, so the `ProtDist` fix (bug 3) touches nothing PROTEUS calls.
- PROTEUS never calls `aOrbHZ`; the planet's orbital distance comes from the PROTEUS config, so the cubic fix (bug 1) does not alter any PROTEUS output.
- The `deepcopy` change (bug 2) is transparent to a single star: it still gets `ExtendedTracks=True` on its own copy, PROTEUS wants that flag on in any case, and the only difference is that the shared default is no longer polluted.
- The cadence check (bug 4) is in a branch PROTEUS cannot reach, and the message fix (bug 5) only changes error text.

Verified end to end against this branch: the PROTEUS star-wrapper unit tests pass, the mors + zephyrus end-to-end integration test passes, and a direct replay of PROTEUS's exact MORS call sequence (spada percentile star, spada period star, Baraffe track, spectrum object) reproduces solar luminosity and radius while leaving `paramsDefault` unmutated across multiple stars.

## Changes

- `physicalmodel.py`: correct the cubic term in all five `aOrbHZ` boundary blocks.
- `star.py`: copy the parameter dictionary before enabling `ExtendedTracks`; route the period-distribution conversion through `physicalmodel._Omega`.
- `cluster.py`: copy the parameter dictionary before enabling `ExtendedTracks`.
- `rotevo.py`: correct the scalar output-cadence proximity check.
- `baraffe.py`: make the missing-file error an f-string and name the correct download command.
- Tests: discriminating tests for each fix in `test_physicalmodel.py`, `test_star.py`, `test_cluster.py`, and `test_rotevo.py`.

## Testing

- Full MORS suite: 274 passed, about 99% line coverage of `src/mors` (unit run on every pull request, integration nightly).
- PROTEUS star-wrapper unit tests: 48 passed.
- PROTEUS mors + zephyrus integration test: 4 passed.
- Direct replay of PROTEUS's MORS call sequence: solar bolometric luminosity and radius reproduced (Lbol 4.13e33 erg/s, Rstar 1.015 Rsun; Baraffe 0.981 Lsun); `paramsDefault` unchanged after building several stars.
