### PR TITLE
Point the coverage badge at the main branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![Docs](https://img.shields.io/github/actions/workflow/status/FormingWorlds/MORS/docs.yaml?branch=main&label=Docs)](https://proteus-framework.org/MORS/)
-[![codecov](https://img.shields.io/codecov/c/github/FormingWorlds/MORS?label=coverage&logo=codecov)](https://app.codecov.io/gh/FormingWorlds/MORS)
+[![codecov](https://img.shields.io/codecov/c/github/FormingWorlds/MORS/main?label=coverage&logo=codecov)](https://app.codecov.io/gh/FormingWorlds/MORS)
 [![Unit Tests](https://img.shields.io/github/actions/workflow/status/FormingWorlds/MORS/tests.yaml?branch=main&label=Unit%20Tests)](https://github.com/FormingWorlds/MORS/actions/workflows/tests.yaml)
 [![Integration Tests](https://img.shields.io/github/actions/workflow/status/FormingWorlds/MORS/nightly.yml?branch=main&label=Integration%20Tests)](https://github.com/FormingWorlds/MORS/actions/workflows/nightly.yml)
 


### PR DESCRIPTION
Read the coverage badge from the main branch so it shows the current line coverage instead of unknown.

- Point the Codecov shields badge at the main branch, matching the branch that the nightly workflow uploads coverage for.
