### PR TITLE
Fix the MORS coupling recipe and versioning docs

### DIFF
--- a/docs/Explanations/proteus.md
+++ b/docs/Explanations/proteus.md
@@ -33,14 +33,14 @@ PROTEUS supports two sets of stellar evolution tracks through MORS, selected via
 !!! warning "Mass clipped outside valid range"
     If the configured stellar mass falls outside the valid range for the chosen tracks, PROTEUS clips it to the nearest limit and logs a warning. Note the difference from standalone MORS: called on its own, `mors.Star` raises for an out-of-range mass. The clipping happens in the PROTEUS star wrapper, before MORS is called.
 
-## Rotation (Spada tracks only)
+## Rotation
 
-For Spada tracks, the initial rotation must be specified using one of two options in the configuration:
+Rotation drives the high-energy evolution on Spada tracks and is set with one of two options in the configuration:
 
 - `star.mors.rot_pcntle`: rotation percentile in the 1 Myr distribution. When set, the reference age is fixed at 1 Myr, consistent with the assumptions in `mors.Percentile()`.
 - `star.mors.rot_period`: rotation period in days at the current stellar age (`star.mors.age_now`).
 
-Only one of these can be set at a time. Baraffe tracks do not use a rotation model.
+Exactly one of the two carries a value; `rot_pcntle` defaults to the 50th (median) percentile, so a configuration that sets neither is accepted and uses the median rotation. Setting both is rejected for any track set. Baraffe tracks have no rotation model, so the value is validated but does not affect the evolution.
 
 ## Stellar spectrum
 

--- a/docs/How-to/proteus_coupling.md
+++ b/docs/How-to/proteus_coupling.md
@@ -18,6 +18,7 @@ tracks          = "spada"     # "spada" or "baraffe"
 age_now         = 4.567       # current stellar age [Gyr]
 rot_pcntle      = 50.0        # rotation percentile (0-100)
 spectrum_source = "solar"     # "solar", "muscles", or "phoenix"
+star_name       = "sun"       # required for "solar" and "muscles"
 ```
 
 ## Choosing the tracks
@@ -41,7 +42,7 @@ For Spada tracks, specify the rotation in exactly one of two ways:
 - `star.mors.rot_pcntle`: a rotation percentile in the 1 Myr distribution (`0` to `100`). The reference age is fixed at 1 Myr, matching `mors.Percentile()`. A percentile of 5 is a slow rotator, 50 the median, 95 a fast rotator.
 - `star.mors.rot_period`: a rotation period in days at the current stellar age `star.mors.age_now`.
 
-Set only one of the two. Baraffe tracks have no rotation model, so both settings are ignored there.
+Set exactly one of the two. The one-of rule is enforced for every MORS configuration: leaving both unset, or setting both, raises a configuration error regardless of the chosen tracks. Baraffe tracks have no rotation model, so the value does not affect the evolution, but the setting is still validated.
 
 ## Choosing the reference spectrum
 
@@ -49,15 +50,15 @@ Set only one of the two. Baraffe tracks have no rotation model, so both settings
 
 | Setting | Behaviour |
 |---|---|
-| `"solar"` | Modern or historical solar reference spectrum |
+| `"solar"` | Modern or historical solar reference spectrum (set `star.mors.star_name`) |
 | `"muscles"` | [MUSCLES](https://archive.stsci.edu/hlsp/muscles) observed spectrum (set `star.mors.star_name`) |
 | `"phoenix"` | [PHOENIX](https://phoenix.astro.physik.uni-goettingen.de/) synthetic spectrum from stellar parameters |
 
-For `"muscles"` and `"phoenix"`, set `star.mors.star_name` to the target star. PROTEUS rescales the chosen spectrum to the planet's orbital separation. Fuller detail on stellar spectra is in the [PROTEUS data reference](https://proteus-framework.org/PROTEUS/Reference/data.html#stellar-spectra).
+For `"solar"` and `"muscles"`, set `star.mors.star_name` to the target star (for the solar reference, `star_name = "sun"`). `"phoenix"` instead builds the spectrum from stellar parameters and does not need `star_name`. PROTEUS rescales the chosen spectrum to the planet's orbital separation. Fuller detail on stellar spectra is in the [PROTEUS data reference](https://proteus-framework.org/PROTEUS/Reference/data.html#stellar-spectra).
 
 ## Common pitfalls
 
-- **Both `rot_pcntle` and `rot_period` set.** Only one initial-rotation setting may be given for Spada tracks; setting both is rejected.
+- **Both `rot_pcntle` and `rot_period` set.** Exactly one initial-rotation setting may be given; setting both, or neither, is rejected for any tracks (including Baraffe).
 - **`age_now` missing or non-positive.** The current stellar age must be greater than zero; it is given in Gyr.
 - **Expecting XUV from Baraffe tracks.** Baraffe tracks provide no XUV; the XUV instellation is set to zero. Use Spada tracks for escape-driving XUV.
 - **Mass outside the track range.** The mass is clipped with a warning, so the simulated star may differ from the configured one. Check the log if the star mass is near a track limit.

--- a/docs/How-to/proteus_coupling.md
+++ b/docs/How-to/proteus_coupling.md
@@ -35,14 +35,14 @@ Use `"spada"` for a rotation-driven XUV history (the usual choice for escape stu
 !!! warning "Mass is clipped to the track range"
     If `star.mass` falls outside the range for the chosen tracks, PROTEUS clips it to the nearest limit and logs a warning rather than failing. Keep the mass inside the track range to avoid a silent change in the star you simulate.
 
-## Setting the initial rotation (Spada only)
+## Setting the initial rotation
 
-For Spada tracks, specify the rotation in exactly one of two ways:
+Rotation drives the XUV history on Spada tracks. Set it with exactly one of two options:
 
 - `star.mors.rot_pcntle`: a rotation percentile in the 1 Myr distribution (`0` to `100`). The reference age is fixed at 1 Myr, matching `mors.Percentile()`. A percentile of 5 is a slow rotator, 50 the median, 95 a fast rotator.
 - `star.mors.rot_period`: a rotation period in days at the current stellar age `star.mors.age_now`.
 
-Set exactly one of the two. The one-of rule is enforced for every MORS configuration: leaving both unset, or setting both, raises a configuration error regardless of the chosen tracks. Baraffe tracks have no rotation model, so the value does not affect the evolution, but the setting is still validated.
+Exactly one of `rot_pcntle` and `rot_period` must carry a value. `rot_pcntle` defaults to 50 (the median rotator), so leaving both keys out is valid and selects the median rotation without raising an error. Setting both to a value raises a configuration error, and so does nulling `rot_pcntle` (setting `rot_pcntle = "none"`) while leaving `rot_period` unset. This check runs for every MORS configuration regardless of the chosen tracks. Baraffe tracks have no rotation model, so the value does not affect the evolution, but the setting is still validated.
 
 ## Choosing the reference spectrum
 
@@ -58,7 +58,7 @@ For `"solar"` and `"muscles"`, set `star.mors.star_name` to the target star (for
 
 ## Common pitfalls
 
-- **Both `rot_pcntle` and `rot_period` set.** Exactly one initial-rotation setting may be given; setting both, or neither, is rejected for any tracks (including Baraffe).
+- **Both `rot_pcntle` and `rot_period` set.** Setting both to a value is rejected for any tracks (including Baraffe). Because `rot_pcntle` defaults to 50, leaving both keys out is accepted and gives the median rotator; the "neither set" error appears only if you null `rot_pcntle` without setting `rot_period`.
 - **`age_now` missing or non-positive.** The current stellar age must be greater than zero; it is given in Gyr.
 - **Expecting XUV from Baraffe tracks.** Baraffe tracks provide no XUV; the XUV instellation is set to zero. Use Spada tracks for escape-driving XUV.
 - **Mass outside the track range.** The mass is clipped with a warning, so the simulated star may differ from the configured one. Check the log if the star mass is near a track limit.

--- a/docs/How-to/releasing.md
+++ b/docs/How-to/releasing.md
@@ -59,7 +59,7 @@ python -c "import mors; print(mors.__version__)"
 
 The reported version drops the leading zeros in the month and day, because setuptools-scm emits PEP 440-canonical versions (see the normalisation note below).
 
-The `0.0.0.dev0` fallback lives in `src/mors/__init__.py` and is used when no `_version.py` has been generated, which happens in a source checkout that was never built or installed. setuptools-scm writes `_version.py` at build and install time, and for that it needs the tag history, so a shallow clone with no tags also leaves the fallback in place. Fetch the tags with `git fetch --tags`. In CI the publish workflow checks out with `fetch-depth: 0` for this reason.
+The `0.0.0.dev0` fallback in `src/mors/__init__.py` is reported only when `_version.py` does not exist, which is the case for a source checkout that was never built or installed; the git tag state does not affect it. Any build or install runs setuptools-scm over the git history and writes `_version.py`, so an installed package never reports `0.0.0.dev0`. A shallow clone matters at build time instead: without the tag history setuptools-scm derives the wrong version, so the published package would carry a development version rather than the intended date. In CI the publish workflow checks out with `fetch-depth: 0` to avoid this; for a local build, fetch the tags first with `git fetch --tags`.
 
 ## Multiple releases on the same day
 

--- a/docs/How-to/releasing.md
+++ b/docs/How-to/releasing.md
@@ -6,7 +6,7 @@ MORS derives its version straight from git tags using [setuptools-scm](https://s
 
 MORS uses [CalVer](https://calver.org/): tags are bare `YY.MM.DD` dates with no leading `v` (for example `26.07.11`). setuptools-scm reads the latest tag on `main` and writes it into `src/mors/_version.py` at build and install time; that file is gitignored and never edited by hand.
 
-Between releases the version is a post-tag development string. With `version_scheme = "no-guess-dev"` a commit made after the `26.07.11` tag reports as `26.07.11.post1.devN+g<hash>`, which is honest about being a development build after that tag rather than a pre-release of a future date. The default `guess-next-dev` scheme would instead invent a next calendar date that could collide with the following day's release tag, which is why `no-guess-dev` is set.
+Between releases the version is a post-tag development string. With `version_scheme = "no-guess-dev"` a commit made after the `26.07.11` tag reports as `26.7.11.post1.devN+g<hash>`, which is honest about being a development build after that tag rather than a pre-release of a future date. The default `guess-next-dev` scheme would instead invent a next calendar date that could collide with the following day's release tag, which is why `no-guess-dev` is set.
 
 ## How to make a release
 
@@ -28,7 +28,7 @@ git push origin 26.07.11
 ```
 
 !!! warning "Tags are bare dates"
-    Use a bare `YY.MM.DD` tag with no leading `v`. setuptools-scm consumes the tag verbatim, and a `v`-prefixed tag produces a non-PEP-440 version that fails the build.
+    Use a bare `YY.MM.DD` tag with no leading `v`, matching MORS's existing release tags. A mixed tag history (some `v`-prefixed, some not) makes the version sequence harder to follow.
 
 ### 3. Create a GitHub release
 
@@ -53,11 +53,13 @@ python -c "import mors; print(mors.__version__)"
 
 | State of the checkout | Reported version |
 |---|---|
-| On the `26.07.11` tag | `26.07.11` |
-| A few commits after the tag | `26.07.11.post1.devN+g<hash>` |
-| No tags found | `0.0.0` fallback |
+| On the `26.07.11` tag | `26.7.11` |
+| A few commits after the tag | `26.7.11.post1.devN+g<hash>` |
+| Source checkout with no generated `_version.py` | `0.0.0.dev0` fallback |
 
-The `0.0.0` fallback means setuptools-scm found no tags, usually because the checkout is shallow. Fetch the tags with `git fetch --tags`. In CI the publish workflow checks out with `fetch-depth: 0` for this reason.
+The reported version drops the leading zeros in the month and day, because setuptools-scm emits PEP 440-canonical versions (see the normalisation note below).
+
+The `0.0.0.dev0` fallback lives in `src/mors/__init__.py` and is used when no `_version.py` has been generated, which happens in a source checkout that was never built or installed. setuptools-scm writes `_version.py` at build and install time, and for that it needs the tag history, so a shallow clone with no tags also leaves the fallback in place. Fetch the tags with `git fetch --tags`. In CI the publish workflow checks out with `fetch-depth: 0` for this reason.
 
 ## Multiple releases on the same day
 
@@ -67,8 +69,8 @@ Append a patch number to the date:
 git tag 26.07.11.1
 ```
 
-This produces version `26.07.11.1`.
+This produces version `26.7.11.1`.
 
-## Note on PyPI normalisation
+## Note on version normalisation
 
-PyPI normalises the version to PEP 440, so a `26.07.11` tag is published as `26.7.11` (leading zeros in the month and day are dropped). This is expected and matches earlier MORS releases.
+setuptools-scm emits PEP 440-canonical versions, so a `26.07.11` tag becomes `26.7.11` (leading zeros in the month and day are dropped) in the built package, the wheel filename, and `mors.__version__`. This normalisation happens locally at build time; PyPI applies the same PEP 440 rule, so the published name matches. This is expected and consistent with earlier MORS releases.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,9 +78,10 @@ include-package-data = true
 # "guess-next-dev" would produce 26.1.3.devN+gHASH for commits after
 # the 26.01.02 tag, claiming a future calendar date that will collide
 # with the next daily release tag. "no-guess-dev" produces
-# 26.01.02.post1.devN+gHASH instead, which is honest about the build
+# 26.1.2.post1.devN+gHASH instead, which is honest about the build
 # being a post-tag development commit rather than a pre-release of
-# the next version.
+# the next version. (setuptools-scm emits PEP 440-canonical versions,
+# so the 26.01.02 tag normalises to 26.1.2, dropping the leading zeros.)
 version_scheme = "no-guess-dev"
 version_file = "src/mors/_version.py"
 


### PR DESCRIPTION
These are corrections to the coupling how-to, the releasing page, and the packaging comments from the last docs standardisation change. Re-reading the new pages against the code, the minimal recipe did not actually run, and several rotation, versioning, and config claims did not match what MORS does.

- Add `star_name = "sun"` to the minimal `[star]` coupling example, which raised a configuration error without it, and fix the `star_name` requirement in the prose and spectrum table (needed for `solar` and `muscles`, not `phoenix`).
- Correct the rotation section: `rot_pcntle` defaults to 50, so leaving both `rot_pcntle` and `rot_period` unset is valid and selects the median rotator; the error appears only when both are set to a value, or the percentile is nulled with no period given. Drop the "(Spada only)" heading qualifier so it no longer contradicts the body, and align the coupling explanation page with the same wording. The one-of check runs for every track set, while only Spada uses the value at runtime.
- Correct the releasing page and the matching `pyproject.toml` comment: versions normalise to `26.7.11` locally via setuptools-scm and PEP 440 (not first at PyPI); the `0.0.0.dev0` fallback in `mors/__init__.py` is a runtime import fallback for an unbuilt source tree, not something a shallow clone triggers (a shallow clone mis-versions the built package instead); and remove the incorrect claim that a `v`-prefixed tag fails the build.

Testing: verified the corrected minimal recipe passes config validation and resolves `star_name = "sun"` to a real solar spectrum end to end; confirmed the rotation validator behaviour against the four documented cases (omit both, both set, nulled percentile, period only) directly against `src/proteus/config/_star.py`; docs build clean with `zensical build --clean`.