### PR TITLE
Key the track-data cache on the dataset MORS ships

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -39,16 +39,33 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[develop]"
 
-      # The key is derived from the dataset pin and the per-file checksums
-      # MORS ships, so it changes exactly when the tracks change. actions/cache
-      # only writes on an exact-key miss, so a key that never changes is never
-      # rewritten and its tree cannot follow the data. The prefix restore-key
-      # gives a run whose dataset moved a warm start from the previous tree.
+      # The key carries the Baraffe dataset pin and the per-file checksums MORS
+      # ships, so it moves when that dataset moves and stays put otherwise.
+      # actions/cache only writes on an exact-key miss, so a key that never
+      # changes is never rewritten and its tree cannot follow the data. An empty
+      # hash would be such a key, and would also collide with the restore-key
+      # prefix, so the step below refuses to build one. The Spada grid shares
+      # the cached tree but is pinned in mors/data.py rather than the manifest,
+      # so this key does not track it.
+      - name: Resolve the track-data cache key
+        id: cachekey
+        run: |
+          hash="${{ hashFiles('src/mors/data/mors_manifest.toml', 'src/mors/data/*.registry.txt') }}"
+          if [ -z "${hash}" ]; then
+            echo "No dataset manifest or registry found under src/mors/data/, so the" >&2
+            echo "cache key has nothing to track. Point the hashFiles patterns in this" >&2
+            echo "workflow at wherever those files now live." >&2
+            exit 1
+          fi
+          echo "key=mors-fwl-data-${hash}" >> "${GITHUB_OUTPUT}"
+
+      # On a run whose dataset moved, the prefix restore-key seeds the new entry
+      # from the previous tree, so only the files that changed come down.
       - name: Cache evolution-track data
         uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}/fwl_data
-          key: mors-fwl-data-${{ hashFiles('src/mors/data/mors_manifest.toml', 'src/mors/data/*.registry.txt') }}
+          key: ${{ steps.cachekey.outputs.key }}
           restore-keys: |
             mors-fwl-data-
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -39,11 +39,18 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[develop]"
 
+      # The key is derived from the dataset pin and the per-file checksums
+      # MORS ships, so it changes exactly when the tracks change. actions/cache
+      # only writes on an exact-key miss, so a key that never changes is never
+      # rewritten and its tree cannot follow the data. The prefix restore-key
+      # gives a run whose dataset moved a warm start from the previous tree.
       - name: Cache evolution-track data
         uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}/fwl_data
-          key: mors-fwl-data-1
+          key: mors-fwl-data-${{ hashFiles('src/mors/data/mors_manifest.toml', 'src/mors/data/*.registry.txt') }}
+          restore-keys: |
+            mors-fwl-data-
 
       - name: Run unit + smoke + integration + slow tests with coverage
         env:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -44,23 +44,37 @@ jobs:
       # actions/cache only writes on an exact-key miss, so a key that never
       # changes is never rewritten and its tree cannot follow the data. An empty
       # hash would be such a key, and would also collide with the restore-key
-      # prefix, so the step below refuses to build one. The Spada grid shares
-      # the cached tree but is pinned in mors/data.py rather than the manifest,
-      # so this key does not track it.
+      # prefix, so the step below refuses to build one. Both inputs are required
+      # rather than either, because hashFiles digests whatever subset it matches:
+      # a renamed registry would otherwise leave a key that still moves with the
+      # pin but no longer tracks the checksums, and nothing would say so. The
+      # Spada grid shares the cached tree but is pinned in mors/data.py rather
+      # than the manifest, so this key does not track it, and re-pinning Spada
+      # serves the cached grid until the cache is cleared.
       - name: Resolve the track-data cache key
         id: cachekey
         run: |
+          if [ ! -f src/mors/data/mors_manifest.toml ] \
+             || ! ls src/mors/data/*.registry.txt >/dev/null 2>&1; then
+            echo "The dataset manifest and its registry are what this key tracks, and" >&2
+            echo "at least one of them is not under src/mors/data/. Point the hashFiles" >&2
+            echo "patterns in this workflow at wherever those files now live." >&2
+            exit 1
+          fi
           hash="${{ hashFiles('src/mors/data/mors_manifest.toml', 'src/mors/data/*.registry.txt') }}"
           if [ -z "${hash}" ]; then
-            echo "No dataset manifest or registry found under src/mors/data/, so the" >&2
-            echo "cache key has nothing to track. Point the hashFiles patterns in this" >&2
-            echo "workflow at wherever those files now live." >&2
+            echo "hashFiles matched nothing under src/mors/data/, so the cache key has" >&2
+            echo "nothing to track. Point the hashFiles patterns in this workflow at" >&2
+            echo "wherever the manifest and registry now live." >&2
             exit 1
           fi
           echo "key=mors-fwl-data-${hash}" >> "${GITHUB_OUTPUT}"
 
-      # On a run whose dataset moved, the prefix restore-key seeds the new entry
-      # from the previous tree, so only the files that changed come down.
+      # A re-pinned dataset lands in a new r<record-id> directory, so its files
+      # come down in full however warm the cache is. The prefix restore-key
+      # seeds the new entry from the previous tree anyway, which is what spares
+      # the data whose own path did not move (the Spada grid, and any dataset
+      # other than the one being re-pinned) from being refetched alongside it.
       - name: Cache evolution-track data
         uses: actions/cache@v4
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -52,6 +52,17 @@ jobs:
           restore-keys: |
             mors-fwl-data-
 
+      - name: Probe restored data tree
+        env:
+          FWL_DATA: ${{ github.workspace }}/fwl_data
+        run: |
+          echo "--- directories under fwl_data ---"
+          find "${FWL_DATA}" -maxdepth 4 -type d 2>/dev/null | sort || echo "(fwl_data absent)"
+          echo "--- resolved Baraffe directory ---"
+          python -c "from mors.data import baraffe_data_dir; p = baraffe_data_dir(); print(p); print('exists:', p.exists()); print('n_files:', len(list(p.glob('*.txt'))) if p.exists() else 0)"
+          echo "--- track file timestamps before the tests ---"
+          find "${FWL_DATA}" -name 'BHAC15-*.txt' -printf '%T@ %p\n' 2>/dev/null | sort | head -3 || true
+
       - name: Run unit + smoke + integration + slow tests with coverage
         env:
           FWL_DATA: ${{ github.workspace }}/fwl_data

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -52,17 +52,6 @@ jobs:
           restore-keys: |
             mors-fwl-data-
 
-      - name: Probe restored data tree
-        env:
-          FWL_DATA: ${{ github.workspace }}/fwl_data
-        run: |
-          echo "--- directories under fwl_data ---"
-          find "${FWL_DATA}" -maxdepth 4 -type d 2>/dev/null | sort || echo "(fwl_data absent)"
-          echo "--- resolved Baraffe directory ---"
-          python -c "from mors.data import baraffe_data_dir; p = baraffe_data_dir(); print(p); print('exists:', p.exists()); print('n_files:', len(list(p.glob('*.txt'))) if p.exists() else 0)"
-          echo "--- track file timestamps before the tests ---"
-          find "${FWL_DATA}" -name 'BHAC15-*.txt' -printf '%T@ %p\n' 2>/dev/null | sort | head -3 || true
-
       - name: Run unit + smoke + integration + slow tests with coverage
         env:
           FWL_DATA: ${{ github.workspace }}/fwl_data

--- a/src/mors/data.py
+++ b/src/mors/data.py
@@ -121,6 +121,10 @@ def get_zenodo_record(folder: str) -> str | None:
         - str | None : Zenodo record ID or None if not found
     """
     # Baraffe is fetched through fwl-io and is intentionally absent here.
+    # This pin sits outside the manifest, so it is outside everything the
+    # nightly cache key hashes, and _download_spada skips the download whenever
+    # the folder is already there. Changing the record here therefore keeps
+    # serving the cached grid until that cache is cleared by hand.
     zenodo_map = {
         'Spada': '15729101',
     }

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -569,17 +569,21 @@ def test_nightly_cache_key_tracks_the_files_that_pin_the_tracks():
     patterns = re.findall(r"'([^']+)'", call.group(1))
     assert patterns, 'the hashFiles call declares no patterns'
 
+    from fwl_io import load_manifest
+
     hashed = {path.resolve() for pattern in patterns for path in repo_root.glob(pattern)}
-    dataset = data._baraffe_dataset()
     manifest = data.manifest_path().resolve()
-    registry = dataset.registry_path.resolve()
+    # Every declared dataset, not just Baraffe, so a dataset added to the
+    # manifest later is covered by this test rather than tripping it.
+    registries = {ds.registry_path.resolve() for ds in load_manifest(manifest)}
+    assert registries, 'the manifest declares no dataset to track'
     # The Zenodo pin lives in the manifest, so a re-pin has to move the key.
     assert manifest in hashed
-    # The per-file checksums live in the registry, so a re-sync has to move it too.
-    assert registry in hashed
+    # The per-file checksums live in the registries, so a re-sync has to move it too.
+    assert registries <= hashed
     # Nothing else: an over-broad pattern would bust the cache on edits that
     # leave the data untouched, which costs a full refetch from a single mirror.
-    assert hashed == {manifest, registry}
+    assert hashed == {manifest} | registries
 
 
 def test_manifest_path_loads_baraffe_dataset():

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -556,6 +556,32 @@ def test_declared_floor_matches_the_error_message_floor():
     assert lower_bounds == [data._FWL_IO_FLOOR]
 
 
+def test_nightly_cache_key_tracks_the_files_that_pin_the_tracks():
+    """The nightly cache key hashes exactly the manifest and registry MORS ships."""
+    import re
+
+    repo_root = Path(__file__).parents[1]
+    workflow = (repo_root / '.github' / 'workflows' / 'nightly.yml').read_text(encoding='utf-8')
+    call = re.search(r'hashFiles\(([^)]*)\)', workflow)
+    # A cache key that stops tracking the data does not fail: the nightly stays
+    # green and quietly refetches every run, so the coupling is pinned here.
+    assert call is not None, 'the nightly no longer derives its cache key from hashFiles'
+    patterns = re.findall(r"'([^']+)'", call.group(1))
+    assert patterns, 'the hashFiles call declares no patterns'
+
+    hashed = {path.resolve() for pattern in patterns for path in repo_root.glob(pattern)}
+    dataset = data._baraffe_dataset()
+    manifest = data.manifest_path().resolve()
+    registry = dataset.registry_path.resolve()
+    # The Zenodo pin lives in the manifest, so a re-pin has to move the key.
+    assert manifest in hashed
+    # The per-file checksums live in the registry, so a re-sync has to move it too.
+    assert registry in hashed
+    # Nothing else: an over-broad pattern would bust the cache on edits that
+    # leave the data untouched, which costs a full refetch from a single mirror.
+    assert hashed == {manifest, registry}
+
+
 def test_manifest_path_loads_baraffe_dataset():
     """The shipped MORS manifest declares Baraffe under the new versioned layout."""
     from fwl_io import load_manifest


### PR DESCRIPTION
The nightly caches the evolution-track tree under a key that never changed. actions/cache writes an entry only when the primary key misses, so a key that always hits is never rewritten: the cached tree stayed frozen at whatever it held the day it was first saved and could not follow the data. When the layout moved to a versioned directory the cache kept serving the old shape, the tracks were missing every night, and every run fetched all 31 Baraffe files from Zenodo instead. Baraffe has no mirror, so that put the nightly at the mercy of whatever Zenodo was doing that morning. It went red three times on 2026-07-23 from read timeouts, each time clearing on a plain re-run.

- Derive the cache key from the dataset pin and the per-file checksums the repo ships, so it changes exactly when the tracks change and stays put otherwise.
- Refuse to build a key when the manifest or the registry is missing, since an empty hash collapses to the bare restore-key prefix and would freeze the tree again, silently.
- Require both inputs rather than either, because hashFiles digests whatever subset it matches: a renamed registry would leave a key that still moves with the pin but no longer tracks the checksums.
- Pin the workflow's hashFiles patterns to the files data.py treats as the pin, with a test, so a key that drifts off the data fails a pull request instead of quietly refetching every night.
- Record at the Spada pin that it sits outside the manifest and therefore outside the key, so re-pinning it serves the cached grid until the cache is cleared.

Scope worth being explicit about: this removes the steady-state Zenodo dependency, not the worst case. A re-pinned dataset lands in a new `r<record-id>` directory, so its files still come down in full, and the first run after this merges misses by construction. Cache eviction and branch-scoped runs also still fetch. The durable fix for those is a second mirror for Baraffe, which is FormingWorlds/fwl-io#4, and a bounded retry around a transient failure, which is FormingWorlds/fwl-io#30.

## Testing

- Unit and smoke tiers: 216 passed locally.
- The new test was mutation-checked in both directions: renaming the registry pattern so it matches nothing fails it, and broadening the pattern to the whole data directory fails it too.
- The key-resolution guard was exercised directly rather than read: it passes on the current tree and exits non-zero both when the manifest is absent and when the registry is absent.
- The workflow still parses, and the job keeps its seven steps in the same order.
