### PR TITLE
Read the fwl-io floor from the metadata instead of repeating it

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
   'matplotlib',
   'numpy>=2.0.0',
   'osfclient',
+  'packaging',
   'platformdirs',
   'scipy',
   'zenodo_get',

--- a/src/mors/data.py
+++ b/src/mors/data.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
+import importlib.metadata
 import logging
 import os
 import shutil
@@ -10,6 +11,8 @@ from time import sleep
 
 import platformdirs
 from osfclient.api import OSF
+from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
 
 log = logging.getLogger('fwl.' + __name__)
 
@@ -25,11 +28,34 @@ project_id = '9u3fb'
 # tarball and still comes down the legacy Zenodo/OSF path below.
 _BARAFFE_KEY = 'star.tracks.baraffe_2015'
 
-# The manifest schema the shipped manifest is written against. An fwl-io older
-# than this reads the manifest as malformed rather than as a version mismatch,
-# so the load names which side is out of date. Keep in step with the fwl-io
-# requirement in pyproject.toml; test_data.py pins the two together.
-_FWL_IO_FLOOR = '26.7.22'
+
+def _required_fwl_io_floor() -> str | None:
+    """Return the fwl-io lower bound this package declares, or None.
+
+    Read from the installed metadata rather than written down a second time
+    here, so the version an error names is the one the requirement states.
+    Returns None when the metadata cannot be read, so a failure to look it up
+    degrades the advice rather than replacing the error being reported.
+    """
+    try:
+        requirements = importlib.metadata.requires('fwl-mors') or ()
+    except Exception:
+        return None
+    for text in requirements:
+        try:
+            requirement = Requirement(text)
+        except Exception:
+            continue
+        if canonicalize_name(requirement.name) != 'fwl-io':
+            continue
+        # A requirement behind a marker, an extra above all, does not state the
+        # floor a plain install resolves.
+        if requirement.marker is not None and not requirement.marker.evaluate():
+            continue
+        for spec in requirement.specifier:
+            if spec.operator in ('>=', '==', '~='):
+                return spec.version
+    return None
 
 
 def _fwl_io_derives_the_location() -> bool:
@@ -69,9 +95,11 @@ def _baraffe_dataset():
     except ValueError as exc:
         if _fwl_io_derives_the_location():
             raise
+        floor = _required_fwl_io_floor()
+        upgrade = f'upgrade to fwl-io>={floor}' if floor else 'upgrade fwl-io'
         raise RuntimeError(
             f'fwl-io could not read the manifest MORS ships ({exc}); the installed '
-            f'fwl-io predates the manifest schema: upgrade to fwl-io>={_FWL_IO_FLOOR}.'
+            f'fwl-io predates the manifest schema: {upgrade}.'
         ) from exc
     return datasets[_BARAFFE_KEY]
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -14,9 +14,11 @@ assertions) do.
 
 from __future__ import annotations
 
+import importlib.metadata
 from pathlib import Path
 
 import pytest
+from packaging.version import Version
 
 import mors.data as data
 
@@ -440,6 +442,30 @@ def test_baraffe_data_dir_rejects_unversioned_fwl_io(monkeypatch, tmp_path):
     assert 'could not read the manifest' not in msg
 
 
+def _declared_fwl_io_floor() -> str:
+    """Return the fwl-io lower bound pyproject.toml states.
+
+    Read straight from the file so a test never takes the version under test's
+    word for what the requirement says.
+    """
+    import tomllib
+
+    from packaging.requirements import Requirement
+    from packaging.utils import canonicalize_name
+
+    pyproject = Path(__file__).parents[1] / 'pyproject.toml'
+    dependencies = tomllib.loads(pyproject.read_text(encoding='utf-8'))['project'][
+        'dependencies'
+    ]
+    declared = [
+        req for req in map(Requirement, dependencies) if canonicalize_name(req.name) == 'fwl-io'
+    ]
+    assert len(declared) == 1, 'exactly one fwl-io requirement, so there is one floor'
+    bounds = [spec.version for spec in declared[0].specifier if spec.operator == '>=']
+    assert len(bounds) == 1, 'the requirement states one lower bound'
+    return bounds[0]
+
+
 def test_stale_fwl_io_is_named_as_the_stale_side(monkeypatch):
     """An fwl-io too old to read the shipped manifest is named as the thing to upgrade."""
 
@@ -455,8 +481,10 @@ def test_stale_fwl_io_is_named_as_the_stale_side(monkeypatch):
     with pytest.raises(RuntimeError) as excinfo:
         data._baraffe_dataset()
     msg = str(excinfo.value)
-    # The reader is sent to the installed package, not to the shipped manifest.
-    assert 'upgrade to fwl-io>=26.7.22' in msg
+    # The reader is sent to the installed package, not to the shipped manifest,
+    # at the version pyproject requires rather than one the code under test
+    # reports about itself.
+    assert f'upgrade to fwl-io>={_declared_fwl_io_floor()}' in msg
     assert 'predates the manifest schema' in msg
     # The underlying complaint is kept, so the failure stays diagnosable.
     assert 'missing required field' in msg
@@ -528,32 +556,95 @@ def test_capability_check_distinguishes_the_two_manifest_schemas(monkeypatch):
     assert data._fwl_io_derives_the_location() is True
 
 
-def test_declared_floor_matches_the_error_message_floor():
-    """The version the errors name is the version the package actually requires."""
-    import tomllib
+def test_floor_read_from_metadata_matches_the_declared_requirement():
+    """The version an error names is the one pyproject requires.
 
-    from packaging.requirements import Requirement
-    from packaging.utils import canonicalize_name
+    The floor is read from the installed metadata, which a development
+    checkout regenerates only on install, so this compares that read against
+    the file that states the requirement.
+    """
+    floor = data._required_fwl_io_floor()
 
-    pyproject = Path(__file__).parents[1] / 'pyproject.toml'
-    dependencies = tomllib.loads(pyproject.read_text(encoding='utf-8'))['project'][
-        'dependencies'
-    ]
-    # Match on the canonical project name, so an extras suffix or an underscore
-    # spelling still resolves to the same requirement instead of silently
-    # leaving the pin unchecked.
-    declared = [
-        req for req in map(Requirement, dependencies) if canonicalize_name(req.name) == 'fwl-io'
-    ]
-    # Exactly one fwl-io requirement, so there is one floor to agree with.
-    assert len(declared) == 1
-    lower_bounds = [spec.version for spec in declared[0].specifier if spec.operator == '>=']
-    # The constant the guards interpolate is the floor the requirement states.
-    # Raising the pin without raising the constant would send users to a version
-    # that no longer satisfies the install. Only the lower bound is read, so
-    # adding an upper bound or an environment marker does not fail this test for
-    # a floor that is still correct.
-    assert lower_bounds == [data._FWL_IO_FLOOR]
+    assert floor == _declared_fwl_io_floor(), (
+        'metadata and pyproject disagree on the fwl-io floor; reinstall the package'
+    )
+    # The environment satisfies the requirement it declares, so the floor an
+    # error names is one the reader can actually install.
+    assert Version(importlib.metadata.version('fwl-io')) >= Version(floor)
+
+
+@pytest.mark.parametrize(
+    ('requirements', 'expected'),
+    [
+        (['astropy>=6.0', 'fwl-io>=26.7.22'], '26.7.22'),
+        (['fwl_io>=26.7.22'], '26.7.22'),
+        (['fwl-io-extras>=9.9.9', 'fwl-io>=26.7.22'], '26.7.22'),
+        (['fwl-io>=99.0; extra == "develop"', 'fwl-io>=26.7.22'], '26.7.22'),
+        (['fwl-io'], None),
+        (['click', 'numpy>=2.0.0'], None),
+    ],
+    ids=[
+        'later-in-list',
+        'underscore-spelling',
+        'prefix-collision',
+        'extra-marker',
+        'no-bound',
+        'absent',
+    ],
+)
+def test_floor_read_picks_the_right_requirement(monkeypatch, requirements, expected):
+    """The floor comes from the fwl-io requirement itself, not from whichever
+    requirement happens to carry a lower bound first.
+
+    Each case is a spelling that a naive scan gets wrong: another package
+    bounded earlier in the list, an underscore name, a package whose name
+    starts with the one sought, and an fwl-io pulled in by an extra rather
+    than by a plain install.
+    """
+    monkeypatch.setattr(importlib.metadata, 'requires', lambda name: list(requirements))
+
+    floor = data._required_fwl_io_floor()
+
+    assert floor == expected
+    # Discrimination: every bound in these lists that belongs to some other
+    # requirement, so picking one up instead would be caught rather than
+    # happening to match.
+    assert floor not in {'6.0', '9.9.9', '99.0', '2.0.0'} - {expected}
+
+
+def test_floor_read_survives_metadata_it_cannot_read(monkeypatch):
+    """A metadata lookup that fails does not replace the error being reported.
+
+    The floor is a detail of the message, so a missing distribution and an
+    unreadable one both have to degrade the advice rather than raise something
+    else on top of the manifest failure.
+    """
+    for failure in (
+        importlib.metadata.PackageNotFoundError('fwl-mors'),
+        PermissionError(13, 'Permission denied'),
+    ):
+
+        def _fails(name, exc=failure):
+            raise exc
+
+        monkeypatch.setattr(importlib.metadata, 'requires', _fails)
+        assert data._required_fwl_io_floor() is None
+
+    def _rejects_the_current_schema(path):
+        raise ValueError(
+            'dataset \'star.tracks.baraffe_2015\': missing required field "subdir"'
+        )
+
+    monkeypatch.setattr('fwl_io.load_manifest', _rejects_the_current_schema)
+    monkeypatch.setattr(data, '_fwl_io_derives_the_location', lambda: False)
+    with pytest.raises(RuntimeError) as excinfo:
+        data._baraffe_dataset()
+    msg = str(excinfo.value)
+    # The version guard still fires and still names fwl-io, without inventing a
+    # version it could not read.
+    assert 'upgrade fwl-io' in msg
+    assert 'upgrade to fwl-io>=' not in msg
+    assert 'predates the manifest schema' in msg
 
 
 def test_nightly_cache_key_tracks_the_files_that_pin_the_tracks():


### PR DESCRIPTION
When fwl-io refuses the manifest MORS ships, MORS says which side is out of date rather than letting a message about a missing field point the reader at a file inside the installed package. The required fwl-io version for that message was written into `data.py` as well as into `pyproject.toml`, so the two had to be kept in step by hand and a test existed only to check that they were.

- The floor comes from the installed metadata, so there is one place to change it.
- Parsed with `packaging` rather than by pattern, so an underscore spelling, a package whose name merely starts the same way, and an fwl-io behind an extra marker all resolve the way pip resolves them.
- A metadata lookup that fails for any reason yields no floor and generic advice, since a detail of the message must not replace the failure being reported.
- `packaging` is declared as a dependency rather than relied on transitively through matplotlib.

The guard itself stays. A diagnosis that lives in a newer fwl-io cannot reach a user running an older one, and the floor in `pyproject.toml` is checked once at install time, so it does not protect an editable checkout, a `--no-deps` image, or an environment where fwl-io was installed separately. Those are the cases this error exists for. This PR is independent of any fwl-io release and changes no behaviour for a correctly installed environment.

**Testing.** Full suite 292 passed. `ruff` clean on both changed files, `tools/check_test_quality.py --check` at 0 versus baseline 0, `validate_test_structure.sh` OK.

Verified by execution against a real released fwl-io 26.07.20 (extracted from the tag and put ahead on `PYTHONPATH`): the error is byte-identical to the one `main` produces, so the diagnosis is intact.

Five mutations, each caught by exactly one test: dropping the package-name match, dropping the extras-marker skip, narrowing the metadata failure catch back to `PackageNotFoundError`, returning a hardcoded floor instead of reading it, and raising the `pyproject` floor without the metadata following, which is the drift the hand-copied constant used to invite.
