### PR TITLE
Stand the live registry check down when Zenodo is unavailable

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -89,7 +89,11 @@ jobs:
         run: |
           FULL_FAIL_UNDER=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['tool']['coverage']['report']['fail_under'])")
           echo "Full gate fail_under: ${FULL_FAIL_UNDER}%"
+          # -rs prints the reason behind every skip. A check that stood down
+          # because an upstream service was unavailable otherwise shows up as a
+          # bare count and reads as if it had run.
           pytest -m "(unit or smoke or integration or slow) and not skip" \
+            -rs \
             --cov=mors \
             --cov-report=term-missing \
             --cov-report=xml \

--- a/tests/test_data_live.py
+++ b/tests/test_data_live.py
@@ -4,10 +4,11 @@ Nightly/slow tier only; needs network. A republished or edited Zenodo deposit is
 caught here instead of by a user's failing fetch.
 
 The fetch is retried a few times, and the check is skipped when zenodo.org stays
-unreachable, rate-limits, or answers with a server error, so an outage upstream
-does not read as registry drift. Every other outcome fails: a checksum that
-disagrees with the committed registry, a partial API response, a record that is
-gone, and a deposit that lists no files.
+unreachable, rate-limits, answers with a server error, or breaks off the response
+body, so an outage upstream does not read as registry drift. Every other outcome
+fails: a checksum that disagrees with the committed registry, a partial API
+response, a body that is not JSON, a record that is gone, and a deposit that
+lists no files.
 """
 
 from __future__ import annotations
@@ -27,7 +28,9 @@ BARAFFE_FILE_COUNT = 31
 # failures.
 TRANSIENT_STATUSES = frozenset({429, 500, 502, 503, 504})
 
-# Attempts per check, spaced by RETRY_BACKOFF_S * 2**attempt seconds.
+# Attempts per check, spaced by RETRY_BACKOFF_S * 2**attempt seconds. The retry
+# absorbs a short stall; a sustained outage is what the skip is for, so raising
+# this does not ride one out.
 FETCH_ATTEMPTS = 3
 RETRY_BACKOFF_S = 5.0
 
@@ -39,6 +42,13 @@ def _upstream_failure(exc: Exception) -> str | None:
     expires first and as an HTTP 5xx when the gateway answers first, so both
     shapes describe the same condition.
     """
+    # A body that broke off mid-transfer carries no status and says nothing
+    # about the deposit, so it is weather like the rest.
+    if isinstance(
+        exc,
+        (requests.exceptions.ChunkedEncodingError, requests.exceptions.ContentDecodingError),
+    ):
+        return 'zenodo.org sent an incomplete response body'
     if isinstance(exc, requests.exceptions.HTTPError):
         status = getattr(exc.response, 'status_code', None)
         if status in TRANSIENT_STATUSES:
@@ -56,7 +66,8 @@ def _fetch_live_registry(doi: str) -> dict[str, str]:
 
     Skips the calling test once the attempts are spent on an unavailable
     zenodo.org. Every other failure propagates: a missing record, a concept DOI,
-    and a deposit that lists no files are defects rather than weather.
+    a body that is not JSON, and a deposit that lists no files are defects
+    rather than weather.
     """
     from fwl_io.sync import fetch_zenodo_registry
 
@@ -71,7 +82,7 @@ def _fetch_live_registry(doi: str) -> dict[str, str]:
             failure = reason
             if attempt < FETCH_ATTEMPTS - 1:
                 time.sleep(RETRY_BACKOFF_S * 2**attempt)
-    pytest.skip(f'{failure} on all {FETCH_ATTEMPTS} attempts; the live registry is unreadable')
+    pytest.skip(f'{failure} on all {FETCH_ATTEMPTS} attempts, so nothing was compared')
 
 
 def test_committed_baraffe_registry_matches_live_zenodo():
@@ -83,8 +94,8 @@ def test_committed_baraffe_registry_matches_live_zenodo():
     live = _fetch_live_registry(ds.zenodo)
     # Guard against a vacuous match on an empty/partial API response.
     assert len(live) == len(committed) == BARAFFE_FILE_COUNT, (
-        f'Zenodo record {ds.zenodo} listed {len(live)} files against '
-        f'{len(committed)} committed, expected {BARAFFE_FILE_COUNT} of each'
+        f'Zenodo record {ds.zenodo} listed {len(live)} files against {len(committed)} '
+        f'committed; BARAFFE_FILE_COUNT expects {BARAFFE_FILE_COUNT} of each'
     )
     # Every committed checksum matches the live deposit; any drift fails here.
     assert live == committed, f'Baraffe registry has drifted from Zenodo record {ds.zenodo}'

--- a/tests/test_data_live.py
+++ b/tests/test_data_live.py
@@ -1,28 +1,90 @@
 """Live check that the committed Baraffe registry matches its Zenodo record.
 
-Nightly/slow tier only; needs network. This re-homes the registry-drift guard
-that previously lived in fwl-io's shared-manifest live test, now that MORS owns
-the Baraffe dataset. A republished or edited Zenodo deposit is caught here
-instead of by a user's failing fetch.
+Nightly/slow tier only; needs network. A republished or edited Zenodo deposit is
+caught here instead of by a user's failing fetch.
+
+The fetch is retried a few times, and the check is skipped when zenodo.org stays
+unreachable, rate-limits, or answers with a server error, so an outage upstream
+does not read as registry drift. Every other outcome fails: a checksum that
+disagrees with the committed registry, a partial API response, a record that is
+gone, and a deposit that lists no files.
 """
 
 from __future__ import annotations
 
+import time
+
 import pytest
+import requests
 
 pytestmark = [pytest.mark.slow, pytest.mark.timeout(3600)]
+
+# Number of track files the committed Baraffe registry pins.
+BARAFFE_FILE_COUNT = 31
+
+# Statuses that mean zenodo.org is busy or unwell rather than the pinned record
+# being wrong: 429 is rate limiting, the 5xx entries are gateway and backend
+# failures.
+TRANSIENT_STATUSES = frozenset({429, 500, 502, 503, 504})
+
+# Attempts per check, spaced by RETRY_BACKOFF_S * 2**attempt seconds.
+FETCH_ATTEMPTS = 3
+RETRY_BACKOFF_S = 5.0
+
+
+def _upstream_failure(exc: Exception) -> str | None:
+    """Report zenodo.org being unavailable, or None for anything else.
+
+    A stalled Zenodo API surfaces as a timeout when the client's own clock
+    expires first and as an HTTP 5xx when the gateway answers first, so both
+    shapes describe the same condition.
+    """
+    if isinstance(exc, requests.exceptions.HTTPError):
+        status = getattr(exc.response, 'status_code', None)
+        if status in TRANSIENT_STATUSES:
+            return f'zenodo.org returned HTTP {status}'
+        return None
+    if isinstance(exc, requests.exceptions.Timeout):
+        return 'zenodo.org did not answer before the request timed out'
+    if isinstance(exc, requests.exceptions.ConnectionError):
+        return 'zenodo.org could not be reached'
+    return None
+
+
+def _fetch_live_registry(doi: str) -> dict[str, str]:
+    """Return a Zenodo record's registry, retrying while the API is stalled.
+
+    Skips the calling test once the attempts are spent on an unavailable
+    zenodo.org. Every other failure propagates: a missing record, a concept DOI,
+    and a deposit that lists no files are defects rather than weather.
+    """
+    from fwl_io.sync import fetch_zenodo_registry
+
+    failure = ''
+    for attempt in range(FETCH_ATTEMPTS):
+        try:
+            return fetch_zenodo_registry(doi)
+        except requests.exceptions.RequestException as exc:
+            reason = _upstream_failure(exc)
+            if reason is None:
+                raise
+            failure = reason
+            if attempt < FETCH_ATTEMPTS - 1:
+                time.sleep(RETRY_BACKOFF_S * 2**attempt)
+    pytest.skip(f'{failure} on all {FETCH_ATTEMPTS} attempts; the live registry is unreadable')
 
 
 def test_committed_baraffe_registry_matches_live_zenodo():
     """The 31 committed Baraffe checksums equal the live Zenodo record's."""
-    from fwl_io.sync import fetch_zenodo_registry
-
     import mors.data as data
 
     ds = data._baraffe_dataset()
     committed = ds.registry()
-    live = fetch_zenodo_registry(ds.zenodo)
+    live = _fetch_live_registry(ds.zenodo)
     # Guard against a vacuous match on an empty/partial API response.
-    assert len(live) == len(committed) == 31
+    assert len(live) == len(committed) == BARAFFE_FILE_COUNT, (
+        f'Zenodo record {ds.zenodo} listed {len(live)} files against '
+        f'{len(committed)} committed, expected {BARAFFE_FILE_COUNT} of each'
+    )
     # Every committed checksum matches the live deposit; any drift fails here.
     assert live == committed, f'Baraffe registry has drifted from Zenodo record {ds.zenodo}'

--- a/tests/test_data_live_guards.py
+++ b/tests/test_data_live_guards.py
@@ -1,0 +1,176 @@
+"""Guards on the live Baraffe registry check in tests/test_data_live.py.
+
+Pins which upstream conditions skip the live check and which still fail it. A
+zenodo.org that stays unreachable, rate-limits, or returns a server error skips
+once the retries are spent; a successful fetch that disagrees with the committed
+registry, a short response, a record that is gone, and a deposit that lists no
+files all fail. The fetch itself is replaced by a stub, so nothing here reaches
+the network.
+"""
+
+from __future__ import annotations
+
+import pytest
+import requests
+import test_data_live as live
+
+pytestmark = [pytest.mark.unit, pytest.mark.timeout(30)]
+
+# Any DOI does, since the fetch is stubbed out; this is the pinned Baraffe one.
+BARAFFE_DOI = '10.5281/zenodo.15729114'
+
+
+class _UnexpectedSkip(Exception):
+    """Raised when the live check skips a condition it is required to fail on."""
+
+
+def _without_skipping(call):
+    """Run ``call``, turning a skip into an error no ``pytest.raises`` block absorbs.
+
+    ``Skipped`` derives from ``BaseException``, so a ``pytest.raises`` block lets
+    it through and the surrounding test reports as skipped rather than failed. A
+    guard blinded that way would read green in CI, which is what this converts.
+    """
+    try:
+        return call()
+    except pytest.skip.Exception as exc:
+        raise _UnexpectedSkip(f'the live check skipped instead of failing: {exc}') from exc
+
+
+class _StubFetch:
+    """Stand-in for the fwl-io registry fetch that counts calls and replays outcomes.
+
+    The last outcome repeats once the list is exhausted, so a single entry
+    describes an upstream condition that persists across every attempt.
+    """
+
+    def __init__(self, *outcomes):
+        self.outcomes = list(outcomes)
+        self.calls = 0
+
+    def __call__(self, doi, **kwargs):
+        self.calls += 1
+        outcome = self.outcomes[min(self.calls - 1, len(self.outcomes) - 1)]
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+
+def _http_error(status: int, kind: str) -> requests.exceptions.HTTPError:
+    """Build the error ``raise_for_status`` raises for a given status code."""
+    response = requests.Response()
+    response.status_code = status
+    response.url = f'https://zenodo.org/api/records/{BARAFFE_DOI.rsplit(".", 1)[-1]}'
+    return requests.exceptions.HTTPError(
+        f'{status} {kind} for url: {response.url}', response=response
+    )
+
+
+def _install(monkeypatch, stub: _StubFetch) -> None:
+    """Route the live check through ``stub`` and drop the backoff to zero."""
+    monkeypatch.setattr('fwl_io.sync.fetch_zenodo_registry', stub)
+    monkeypatch.setattr(live, 'RETRY_BACKOFF_S', 0.0)
+
+
+def _committed() -> dict[str, str]:
+    """Return the committed Baraffe registry, read from the shipped file."""
+    import mors.data as data
+
+    return data._baraffe_dataset().registry()
+
+
+def test_sustained_gateway_error_skips_the_live_check(monkeypatch):
+    """A Zenodo gateway that answers 504 on every attempt skips, not fails."""
+    stub = _StubFetch(_http_error(504, 'Server Error'))
+    _install(monkeypatch, stub)
+    with pytest.raises(pytest.skip.Exception, match='HTTP 504'):
+        live.test_committed_baraffe_registry_matches_live_zenodo()
+    # Every attempt is spent before giving up, so a stall shorter than the
+    # backoff window still completes the check.
+    assert stub.calls == live.FETCH_ATTEMPTS
+    assert live.FETCH_ATTEMPTS > 1
+
+
+def test_sustained_read_timeout_skips_the_live_check(monkeypatch):
+    """A Zenodo API that never answers within the client timeout skips, not fails.
+
+    The same outage reaches the check as a timeout or as a 5xx depending on
+    which clock expires first, so both shapes are pinned.
+    """
+    stalled = requests.exceptions.ReadTimeout(
+        "HTTPSConnectionPool(host='zenodo.org', port=443): Read timed out. (read timeout=30)"
+    )
+    stub = _StubFetch(stalled)
+    _install(monkeypatch, stub)
+    with pytest.raises(pytest.skip.Exception, match='timed out'):
+        live.test_committed_baraffe_registry_matches_live_zenodo()
+    assert stub.calls == live.FETCH_ATTEMPTS
+    assert live.FETCH_ATTEMPTS > 1
+
+
+def test_unreachable_host_skips_the_live_check(monkeypatch):
+    """A zenodo.org that cannot be reached at all skips, not fails."""
+    stub = _StubFetch(requests.exceptions.ConnectionError('Name or service not known'))
+    _install(monkeypatch, stub)
+    with pytest.raises(pytest.skip.Exception, match='could not be reached'):
+        live.test_committed_baraffe_registry_matches_live_zenodo()
+    assert stub.calls == live.FETCH_ATTEMPTS
+    assert live.FETCH_ATTEMPTS > 1
+
+
+def test_a_single_stall_is_absorbed_by_the_retry(monkeypatch):
+    """One stalled attempt followed by an answer completes the check."""
+    stub = _StubFetch(requests.exceptions.ReadTimeout('Read timed out.'), _committed())
+    _install(monkeypatch, stub)
+    _without_skipping(live.test_committed_baraffe_registry_matches_live_zenodo)
+    # The second attempt is what answered, so the retry did the work rather
+    # than the first call having quietly succeeded.
+    assert stub.calls == 2
+    assert live.FETCH_ATTEMPTS > 1
+
+
+def test_missing_record_fails_the_live_check(monkeypatch):
+    """A pinned record that is gone from Zenodo fails, and is not retried."""
+    stub = _StubFetch(_http_error(404, 'Client Error'))
+    _install(monkeypatch, stub)
+    with pytest.raises(requests.exceptions.HTTPError, match='404 Client Error'):
+        _without_skipping(live.test_committed_baraffe_registry_matches_live_zenodo)
+    # A record that is gone stays gone, so retrying it would only add delay.
+    assert stub.calls == 1
+
+
+def test_deposit_without_files_fails_the_live_check(monkeypatch):
+    """A record whose deposit lists no files fails, and is not retried."""
+    stub = _StubFetch(ValueError('Zenodo record 15729114 lists no files'))
+    _install(monkeypatch, stub)
+    with pytest.raises(ValueError, match='lists no files'):
+        _without_skipping(live.test_committed_baraffe_registry_matches_live_zenodo)
+    assert stub.calls == 1
+
+
+def test_drifted_checksum_fails_the_live_check(monkeypatch):
+    """A republished deposit with one changed checksum fails on the comparison."""
+    drifted = dict(_committed())
+    first = sorted(drifted)[0]
+    # A checksum that cannot collide with a real md5 digest, so the failure is
+    # unambiguously the drift and not a coincidence.
+    drifted[first] = 'md5:' + '0' * 32
+    stub = _StubFetch(drifted)
+    _install(monkeypatch, stub)
+    with pytest.raises(AssertionError, match='drifted from Zenodo record'):
+        _without_skipping(live.test_committed_baraffe_registry_matches_live_zenodo)
+    assert stub.calls == 1
+
+
+def test_partial_response_fails_the_live_check(monkeypatch):
+    """A response listing fewer files than the record holds fails on the count."""
+    partial = dict(_committed())
+    partial.pop(sorted(partial)[0])
+    stub = _StubFetch(partial)
+    _install(monkeypatch, stub)
+    with pytest.raises(AssertionError, match='listed 30 files') as excinfo:
+        _without_skipping(live.test_committed_baraffe_registry_matches_live_zenodo)
+    # The count guard is what fires: a short response never reaches the
+    # checksum comparison, so it cannot be reported as drift.
+    assert 'drifted' not in str(excinfo.value)
+    assert stub.calls == 1

--- a/tests/test_data_live_guards.py
+++ b/tests/test_data_live_guards.py
@@ -1,23 +1,30 @@
 """Guards on the live Baraffe registry check in tests/test_data_live.py.
 
 Pins which upstream conditions skip the live check and which still fail it. A
-zenodo.org that stays unreachable, rate-limits, or returns a server error skips
-once the retries are spent; a successful fetch that disagrees with the committed
-registry, a short response, a record that is gone, and a deposit that lists no
-files all fail. The fetch itself is replaced by a stub, so nothing here reaches
-the network.
+zenodo.org that stays unreachable, rate-limits, returns a server error, or breaks
+off the response body skips once the retries are spent; a successful fetch that
+disagrees with the committed registry, a short response, a body that is not JSON,
+a record that is gone, and a deposit that lists no files all fail. The fetch
+itself is replaced by a stub, so nothing here reaches the network.
 """
 
 from __future__ import annotations
 
 import pytest
 import requests
+
+# tests/ carries no __init__.py, so pytest's default import mode puts it on
+# sys.path and the sibling module resolves by bare name.
 import test_data_live as live
+
+import mors.data as data
 
 pytestmark = [pytest.mark.unit, pytest.mark.timeout(30)]
 
-# Any DOI does, since the fetch is stubbed out; this is the pinned Baraffe one.
-BARAFFE_DOI = '10.5281/zenodo.15729114'
+# The statuses the live check is required to read as weather. Pinned here rather
+# than read from the source, so narrowing the source set fails a test instead of
+# quietly collecting fewer cases.
+EXPECTED_TRANSIENT = (429, 500, 502, 503, 504)
 
 
 class _UnexpectedSkip(Exception):
@@ -56,11 +63,18 @@ class _StubFetch:
         return outcome
 
 
-def _http_error(status: int, kind: str) -> requests.exceptions.HTTPError:
+def _record_url() -> str:
+    """Return the pinned record's API URL, read from the shipped manifest."""
+    record_id = data._baraffe_dataset().zenodo.rsplit('.', 1)[-1]
+    return f'https://zenodo.org/api/records/{record_id}'
+
+
+def _http_error(status: int) -> requests.exceptions.HTTPError:
     """Build the error ``raise_for_status`` raises for a given status code."""
     response = requests.Response()
     response.status_code = status
-    response.url = f'https://zenodo.org/api/records/{BARAFFE_DOI.rsplit(".", 1)[-1]}'
+    response.url = _record_url()
+    kind = 'Client Error' if status < 500 else 'Server Error'
     return requests.exceptions.HTTPError(
         f'{status} {kind} for url: {response.url}', response=response
     )
@@ -68,25 +82,40 @@ def _http_error(status: int, kind: str) -> requests.exceptions.HTTPError:
 
 def _install(monkeypatch, stub: _StubFetch) -> None:
     """Route the live check through ``stub`` and drop the backoff to zero."""
+    # The stub only lands because the fetch is imported inside the function
+    # under test, so the name is looked up on fwl_io.sync at call time.
+    assert not hasattr(live, 'fetch_zenodo_registry')
     monkeypatch.setattr('fwl_io.sync.fetch_zenodo_registry', stub)
     monkeypatch.setattr(live, 'RETRY_BACKOFF_S', 0.0)
 
 
 def _committed() -> dict[str, str]:
     """Return the committed Baraffe registry, read from the shipped file."""
-    import mors.data as data
-
     return data._baraffe_dataset().registry()
 
 
-def test_sustained_gateway_error_skips_the_live_check(monkeypatch):
-    """A Zenodo gateway that answers 504 on every attempt skips, not fails."""
-    stub = _StubFetch(_http_error(504, 'Server Error'))
+def test_the_transient_status_set_is_the_pinned_one():
+    """The statuses read as weather are the rate-limit and server-error codes."""
+    assert live.TRANSIENT_STATUSES == frozenset(EXPECTED_TRANSIENT)
+    # A record that is gone is a defect, so its status must never be in the set.
+    assert 404 not in live.TRANSIENT_STATUSES
+
+
+def test_the_fetch_is_retried_with_a_growing_wait():
+    """The check makes more than one attempt, and waits between them."""
+    assert live.FETCH_ATTEMPTS > 1
+    assert live.RETRY_BACKOFF_S > 0
+
+
+@pytest.mark.parametrize('status', EXPECTED_TRANSIENT)
+def test_every_transient_status_skips_the_live_check(monkeypatch, status):
+    """Each status MORS reads as an unwell zenodo.org skips rather than fails."""
+    stub = _StubFetch(_http_error(status))
     _install(monkeypatch, stub)
-    with pytest.raises(pytest.skip.Exception, match='HTTP 504'):
+    with pytest.raises(pytest.skip.Exception, match=f'HTTP {status}'):
         live.test_committed_baraffe_registry_matches_live_zenodo()
-    # Every attempt is spent before giving up, so a stall shorter than the
-    # backoff window still completes the check.
+    # Every attempt is spent before giving up, and there is more than one, so a
+    # status that clears partway through still completes the check.
     assert stub.calls == live.FETCH_ATTEMPTS
     assert live.FETCH_ATTEMPTS > 1
 
@@ -118,6 +147,30 @@ def test_unreachable_host_skips_the_live_check(monkeypatch):
     assert live.FETCH_ATTEMPTS > 1
 
 
+@pytest.mark.parametrize(
+    'error',
+    [
+        requests.exceptions.ChunkedEncodingError('Connection broken: IncompleteRead'),
+        requests.exceptions.ContentDecodingError(
+            'Received response with content-encoding: gzip'
+        ),
+    ],
+    ids=['truncated_body', 'undecodable_body'],
+)
+def test_incomplete_response_body_skips_the_live_check(monkeypatch, error):
+    """A response body that does not arrive intact skips, not fails.
+
+    Neither class carries a status code, so the classifier has to recognise
+    them by type rather than through the status branch.
+    """
+    stub = _StubFetch(error)
+    _install(monkeypatch, stub)
+    with pytest.raises(pytest.skip.Exception, match='incomplete response body'):
+        live.test_committed_baraffe_registry_matches_live_zenodo()
+    assert stub.calls == live.FETCH_ATTEMPTS
+    assert live.FETCH_ATTEMPTS > 1
+
+
 def test_a_single_stall_is_absorbed_by_the_retry(monkeypatch):
     """One stalled attempt followed by an answer completes the check."""
     stub = _StubFetch(requests.exceptions.ReadTimeout('Read timed out.'), _committed())
@@ -129,13 +182,48 @@ def test_a_single_stall_is_absorbed_by_the_retry(monkeypatch):
     assert live.FETCH_ATTEMPTS > 1
 
 
+def test_the_retry_waits_longer_after_each_attempt(monkeypatch):
+    """The gap between attempts grows, so a struggling Zenodo is not hammered."""
+    waits: list[float] = []
+    monkeypatch.setattr(live.time, 'sleep', waits.append)
+    stub = _StubFetch(_http_error(503))
+    monkeypatch.setattr('fwl_io.sync.fetch_zenodo_registry', stub)
+    with pytest.raises(pytest.skip.Exception, match='HTTP 503'):
+        live.test_committed_baraffe_registry_matches_live_zenodo()
+    # One wait fewer than attempts: the last failure skips instead of sleeping.
+    assert len(waits) == live.FETCH_ATTEMPTS - 1
+    assert waits[0] > 0
+    assert all(later > earlier for earlier, later in zip(waits, waits[1:]))
+
+
 def test_missing_record_fails_the_live_check(monkeypatch):
     """A pinned record that is gone from Zenodo fails, and is not retried."""
-    stub = _StubFetch(_http_error(404, 'Client Error'))
+    stub = _StubFetch(_http_error(404))
     _install(monkeypatch, stub)
     with pytest.raises(requests.exceptions.HTTPError, match='404 Client Error'):
         _without_skipping(live.test_committed_baraffe_registry_matches_live_zenodo)
     # A record that is gone stays gone, so retrying it would only add delay.
+    assert stub.calls == 1
+
+
+def test_missing_record_after_a_stall_fails_the_live_check(monkeypatch):
+    """A 404 arriving on a retry fails there, rather than being absorbed."""
+    stub = _StubFetch(_http_error(503), _http_error(404))
+    _install(monkeypatch, stub)
+    with pytest.raises(requests.exceptions.HTTPError, match='404 Client Error'):
+        _without_skipping(live.test_committed_baraffe_registry_matches_live_zenodo)
+    # The earlier stall must not carry the run to a skip and bury the 404.
+    assert stub.calls == 2
+
+
+def test_non_json_body_fails_the_live_check(monkeypatch):
+    """A response carrying something other than JSON fails, and is not retried."""
+    stub = _StubFetch(requests.exceptions.JSONDecodeError('Expecting value', '<html>', 0))
+    _install(monkeypatch, stub)
+    with pytest.raises(requests.exceptions.JSONDecodeError):
+        _without_skipping(live.test_committed_baraffe_registry_matches_live_zenodo)
+    # A body that is not JSON says nothing about the deposit, so reading it as
+    # weather would hide a change in what the API returns.
     assert stub.calls == 1
 
 
@@ -168,7 +256,8 @@ def test_partial_response_fails_the_live_check(monkeypatch):
     partial.pop(sorted(partial)[0])
     stub = _StubFetch(partial)
     _install(monkeypatch, stub)
-    with pytest.raises(AssertionError, match='listed 30 files') as excinfo:
+    expected = rf'listed {live.BARAFFE_FILE_COUNT - 1} files'
+    with pytest.raises(AssertionError, match=expected) as excinfo:
         _without_skipping(live.test_committed_baraffe_registry_matches_live_zenodo)
     # The count guard is what fires: a short response never reaches the
     # checksum comparison, so it cannot be reported as drift.


### PR DESCRIPTION
The nightly check that compares the committed Baraffe registry against its Zenodo record fetched the record once, with a thirty second timeout and no retry, so any stall at zenodo.org turned the whole nightly red on a test whose purpose has nothing to do with network health. That is what happened on 7 August, where it was the only failure out of 289.

- Retry the registry fetch three times with a doubling backoff, and skip the check with a message naming the upstream condition once the attempts are spent on a zenodo.org that stays unreachable, rate-limits, answers with a server error, or breaks off the response body.
- Keep every other outcome failing: a fetch that succeeds and disagrees with the committed registry, a response listing fewer files than the record holds, a body that is not JSON, a record that is gone, and a deposit that lists no files.
- Add `tests/test_data_live_guards.py`, which stubs the fetch and pins that boundary in the unit tier, so the split runs on every pull request rather than only in the nightly.
- Pass `-rs` in the nightly, because pytest otherwise prints a bare skip count and drops the reason the message was written for.

The same stall reaches the check as a client timeout or as an HTTP 5xx depending on which clock expires first, so both shapes map to the same condition.

I verified the boundary by injecting faults rather than by waiting for weather: a 504 and a read timeout stand the check down, while a drifted checksum, a missing record and a thirty of thirty one response all still fail. Mutating the classifier to treat every error as transient, or weakening the drift comparison, fails the guards rather than skipping them.
