### PR TITLE
Raise a check that did not run to the nightly run summary

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -94,10 +94,51 @@ jobs:
           # bare count and reads as if it had run.
           pytest -m "(unit or smoke or integration or slow) and not skip" \
             -rs \
+            --junit-xml=report.xml \
             --cov=mors \
             --cov-report=term-missing \
             --cov-report=xml \
             --cov-fail-under=${FULL_FAIL_UNDER}
+
+      # A check that did not run leaves the run green, so it is raised to the
+      # run summary here rather than left in the body of a long log.
+      - name: Report checks that did not run
+        if: ${{ always() }}
+        run: |
+          python - <<'PY'
+          import pathlib, xml.etree.ElementTree as ET
+
+          # A marker-deselected test leaves no element in the report at all, so
+          # these are looked for by name rather than waited on to appear.
+          MUST_RUN = {
+              'tests.test_data_live.test_committed_baraffe_registry_matches_live_zenodo',
+          }
+
+          # An unreadable report earns a warning rather than a failure, since it
+          # means the run was killed before it finished writing one.
+          try:
+              root = ET.parse(pathlib.Path('report.xml')).getroot()
+          except (OSError, ET.ParseError) as exc:
+              print(f'::warning::the test report could not be read ({exc}), so any '
+                    'check that did not run is unreported')
+              raise SystemExit(0)
+
+          ran = set()
+          for case in root.iter('testcase'):
+              name = f'{case.get("classname", "")}.{case.get("name", "")}'.strip('.')
+              ran.add(name)
+              for skipped in case.iter('skipped'):
+                  # Collapsing whitespace keeps a reason from carrying a line
+                  # break into the annotation, where it would start a new one.
+                  reason = ' '.join((skipped.get('message') or 'no reason given').split())
+                  print(f'::warning::{name} did not run: {reason}')
+
+          missing = sorted(MUST_RUN - ran)
+          for name in missing:
+              print(f'::error::{name} is absent from the test report, so it was '
+                    'deselected or renamed rather than run')
+          raise SystemExit(1 if missing else 0)
+          PY
 
       - name: Upload coverage to Codecov
         if: ${{ !cancelled() }}

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ pip-delete-this-directory.txt
 .cache
 nosetests.xml
 coverage.xml
+report.xml
 
 # Translations
 *.mo


### PR DESCRIPTION
## Description

The nightly reports a check that did not run. A test deselected by a marker leaves no element in the JUnit report at all, so a scan looking for skips finds nothing and the run reads as though everything was exercised. The summary now names the checks that were expected by name and says which of them produced no result, so a check quietly dropping out of the selection is visible rather than silent.

The step that reads the report is also guarded. `ET.parse` on a truncated `report.xml` raises, which failed the step itself and lost the summary along with it. A run that is cancelled or times out is exactly when the file is half written, and it is also exactly when the summary is most worth having, so the parse tolerates a truncated or unreadable file and says so instead of crashing. The condition on the step widens from "not cancelled" to always, for the same reason: the runs the truncation comes from were the ones being skipped.

Reasons are collapsed with `' '.join(split())` rather than a newline replacement, so a carriage return, a tab, or a run of whitespace inside a skip reason cannot open a second annotation.

## Validation of changes

Verified against a truncated report, an unreadable one, and a well-formed one: the first two produce the summary with a line naming what could not be read, and the well-formed case is unchanged. A marker-deselected test is reported as having produced no result, which is the case that motivated this. Whitespace inside a reason no longer splits the annotation. The nightly on `main` is green, so this is hardening rather than a repair: nothing is currently broken by it. Tested on macOS with Python 3.12.

## Checklist

- [x] I have followed the [contributing guidelines](https://proteus-framework.org/PROTEUS/CONTRIBUTING.html#how-do-i-contribute)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [x] I have updated the docs, as appropriate
- [x] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required
